### PR TITLE
Fix for 'usings outside namespace' scrubbing the existing file-level usings

### DIFF
--- a/src/Unitverse.Core/CoreGenerator.cs
+++ b/src/Unitverse.Core/CoreGenerator.cs
@@ -142,7 +142,7 @@
                     // find all the usings that are in targetNamespace, but not declared in either the originalTargetNamespace or the compilation
                     var usings = targetNamespace.Usings.Where(x => !existingUsings.Contains(x.NormalizeWhitespace().ToFullString())).ToList();
 
-                    MoveUsingsToCompilation(ref compilation, ref targetNamespace, usings);
+                    MoveUsingsToCompilation(ref compilation, ref targetNamespace, compilation.Usings.Concat(usings).ToList());
                 }
             }
 


### PR DESCRIPTION
Resolves #60 

Opening a separate item to enhance the testing of generation over an existing class