### PR TITLE
Ability to have a separate .unitTestGeneratorConfig per-project

### DIFF
--- a/src/Unitverse.Core/Options/UnitTestGeneratorOptionsFactory.cs
+++ b/src/Unitverse.Core/Options/UnitTestGeneratorOptionsFactory.cs
@@ -1,26 +1,20 @@
 ﻿namespace Unitverse.Core.Options
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using EditorConfig.Core;
 
     public static class UnitTestGeneratorOptionsFactory
     {
-        public static IUnitTestGeneratorOptions Create(string solutionFilePath, IGenerationOptions generationOptions, INamingOptions namingOptions, IStrategyOptions strategyOptions, bool statisticsGenerationEnabled)
+        public static IUnitTestGeneratorOptions Create(string projectFilePath, IGenerationOptions generationOptions, INamingOptions namingOptions, IStrategyOptions strategyOptions, bool statisticsGenerationEnabled)
         {
-            if (generationOptions == null)
-            {
-                throw new ArgumentNullException(nameof(generationOptions));
-            }
-
             var mutableGenerationOptions = new MutableGenerationOptions(generationOptions);
             var mutableNamingOptions = new MutableNamingOptions(namingOptions);
             var mutableStrategyOptions = new MutableStrategyOptions(strategyOptions);
 
-            if (!string.IsNullOrWhiteSpace(solutionFilePath))
+            if (!string.IsNullOrWhiteSpace(projectFilePath))
             {
-                var allFiles = new EditorConfigParser(CoreConstants.ConfigFileName).GetConfigurationFilesTillRoot(solutionFilePath);
+                var allFiles = new EditorConfigParser(CoreConstants.ConfigFileName).GetConfigurationFilesTillRoot(projectFilePath);
                 var allProperties = allFiles.SelectMany(x => x.Sections).SelectMany(x => x);
                 var properties = new Dictionary<string, string>();
                 foreach (var pair in allProperties)

--- a/src/Unitverse/Commands/GoToUnitTestsCommand.cs
+++ b/src/Unitverse/Commands/GoToUnitTestsCommand.cs
@@ -52,7 +52,7 @@
             menuItem.BeforeQueryStatus += (s, e) =>
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
-                menuItem.Visible = SolutionUtilities.GetSelectedFiles(_dte, false, _package.Options.GenerationOptions).Any(ProjectItemModel.IsSupported);
+                menuItem.Visible = SolutionUtilities.GetSupportedFiles(_dte, false).Any();
             };
 
             commandService.AddCommand(menuItem);
@@ -85,21 +85,22 @@
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                var options = _package.Options;
-                var source = SolutionUtilities.GetSelectedFiles(_dte, false, options.GenerationOptions).FirstOrDefault(ProjectItemModel.IsSupported);
+                var source = SolutionUtilities.GetSupportedFiles(_dte, false).FirstOrDefault();
                 if (source == null)
                 {
                     throw new InvalidOperationException("Cannot go to tests for this item because no supported files were found");
                 }
 
-                var status = TargetFinder.FindExistingTargetItem(source, options.GenerationOptions, out var targetItem);
+                var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, _package.Options);
+
+                var status = TargetFinder.FindExistingTargetItem(source, mapping, out var targetItem);
                 switch (status)
                 {
                     case FindTargetStatus.FileNotFound:
                     case FindTargetStatus.FolderNotFound:
                         throw new InvalidOperationException("No unit tests were found for the selected file.");
                     case FindTargetStatus.ProjectNotFound:
-                        throw new InvalidOperationException("Cannot go to tests for this item because there is no project '" + source.TargetProjectName + "'");
+                        throw new InvalidOperationException("Cannot go to tests for this item because there is no project '" + mapping.TargetProjectName + "'");
                 }
 
                 VsProjectHelper.ActivateItem(targetItem);

--- a/src/Unitverse/Commands/GoToUnitTestsForSymbolCommand.cs
+++ b/src/Unitverse/Commands/GoToUnitTestsForSymbolCommand.cs
@@ -102,17 +102,17 @@
 
                 var item = VsProjectHelper.GetProjectItem(document.FilePath);
 
-                var options = _package.Options;
-                var source = new ProjectItemModel(item, options.GenerationOptions);
+                var source = new ProjectItemModel(item);
+                var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, _package.Options);
 
-                var status = TargetFinder.FindExistingTargetItem(source, options.GenerationOptions, out var targetItem);
+                var status = TargetFinder.FindExistingTargetItem(source, mapping, out var targetItem);
                 switch (status)
                 {
                     case FindTargetStatus.FileNotFound:
                     case FindTargetStatus.FolderNotFound:
                         throw new InvalidOperationException("No unit tests were found for the selected file.");
                     case FindTargetStatus.ProjectNotFound:
-                        throw new InvalidOperationException("Cannot go to tests for this item because there is no project '" + source.TargetProjectName + "'");
+                        throw new InvalidOperationException("Cannot go to tests for this item because there is no project '" + mapping.TargetProjectName + "'");
                 }
 
                 VsProjectHelper.ActivateItem(targetItem);

--- a/src/Unitverse/Helper/ProjectItemModel.cs
+++ b/src/Unitverse/Helper/ProjectItemModel.cs
@@ -1,38 +1,18 @@
 ﻿namespace Unitverse.Helper
 {
     using System;
-    using System.Globalization;
     using EnvDTE;
     using Microsoft.VisualStudio.Shell;
-    using Unitverse.Core.Helpers;
-    using Unitverse.Core.Options;
-    using Unitverse.Properties;
 
     public class ProjectItemModel
     {
-        private Project _targetProject;
-
-        public ProjectItemModel(ProjectItem projectItem, IGenerationOptions options)
+        public ProjectItemModel(ProjectItem projectItem)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
             ThreadHelper.ThrowIfNotOnUIThread();
 
             Item = projectItem ?? throw new ArgumentNullException(nameof(projectItem));
             FilePath = projectItem.FileNames[1];
-            TargetProjectName = options.GetTargetProjectName(Item.ContainingProject.Name);
             SourceProjectName = Item.ContainingProject.Name;
-            try
-            {
-                TargetProjectName = string.Format(CultureInfo.CurrentCulture, options.TestProjectNaming, Item.ContainingProject.Name);
-            }
-            catch (FormatException)
-            {
-                throw new InvalidOperationException(Strings.ProjectItemModel_ProjectItemModel_Cannot_not_derive_target_project_name__please_check_the_test_project_naming_setting_);
-            }
         }
 
         public string FilePath { get; }
@@ -48,23 +28,8 @@
             }
         }
 
-        public Project TargetProject
-        {
-            get
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-
-                return _targetProject ?? (_targetProject = VsProjectHelper.FindProject(Item.DTE.Solution, TargetProjectName));
-            }
-        }
-
         public string SourceProjectName { get; }
 
-        public string TargetProjectName { get; }
-
-        public static bool IsSupported(ProjectItemModel item)
-        {
-            return item?.FilePath != null && item.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
-        }
+        public bool IsSupported => FilePath != null && FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Unitverse/Helper/ProjectMapping.cs
+++ b/src/Unitverse/Helper/ProjectMapping.cs
@@ -1,24 +1,43 @@
 ﻿using EnvDTE;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using Unitverse.Core.Assets;
+using Unitverse.Core.Helpers;
 using Unitverse.Core.Options;
 
 namespace Unitverse.Helper
 {
     public class ProjectMapping
     {
-        public ProjectMapping(Project sourceProject, Project targetProject, IUnitTestGeneratorOptions options)
+        public ProjectMapping(Project sourceProject, Project targetProject, string targetProjectName, IUnitTestGeneratorOptions options)
         {
             SourceProject = sourceProject ?? throw new ArgumentNullException(nameof(sourceProject));
-            TargetProject = targetProject ?? throw new ArgumentNullException(nameof(targetProject));
+            TargetProject = targetProject;
+            TargetProjectName = targetProjectName;
             Options = options ?? throw new ArgumentNullException(nameof(options));
             TargetAssets = new HashSet<TargetAsset>();
         }
 
         public Project SourceProject { get; }
         public Project TargetProject { get; }
+        public string TargetProjectName { get; }
         public IUnitTestGeneratorOptions Options { get; }
         public HashSet<TargetAsset> TargetAssets { get; }
+
+        public Func<string, string> CreateNamespaceTransform()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var sourceNameSpaceRoot = VsProjectHelper.GetProjectRootNamespace(SourceProject);
+
+            if (TargetProject != null)
+            {
+                var targetNameSpaceRoot = VsProjectHelper.GetProjectRootNamespace(TargetProject);
+                return NamespaceTransform.Create(sourceNameSpaceRoot, targetNameSpaceRoot);
+            }
+
+            return x => x + ".Tests";
+        }
     }
 }

--- a/src/Unitverse/Helper/ProjectMappingFactory.cs
+++ b/src/Unitverse/Helper/ProjectMappingFactory.cs
@@ -1,0 +1,33 @@
+﻿namespace Unitverse.Helper
+{
+    using EnvDTE;
+    using Microsoft.VisualStudio.Shell;
+    using Unitverse.Core.Helpers;
+    using Unitverse.Core.Options;
+
+    internal class ProjectMappingFactory
+    {
+        public static ProjectMapping CreateMappingFor(Project sourceProject, IUnitTestGeneratorOptions baseOptions)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // resolve the options for this project
+            var projectOptions = UnitTestGeneratorOptionsFactory.Create(sourceProject.FileName, baseOptions.GenerationOptions, baseOptions.NamingOptions, baseOptions.StrategyOptions, baseOptions.StatisticsCollectionEnabled);
+
+            // derive the target project name
+            var targetProjectName = projectOptions.GenerationOptions.GetTargetProjectName(sourceProject.Name);
+            
+            // find the target project
+            var targetProject = VsProjectHelper.FindProject(sourceProject.DTE.Solution, targetProjectName);
+
+            // now resolve the frameworks in use by the target project (if target project is not null and options allow)
+            var generationOptions = OptionsResolver.DetectFrameworks(targetProject, projectOptions.GenerationOptions);
+
+            // now create the final options, including resolved frameworks
+            var finalOptions = new UnitTestGeneratorOptions(generationOptions, projectOptions.NamingOptions, projectOptions.StrategyOptions, projectOptions.StatisticsCollectionEnabled);
+
+            // now return the mapping from source to target, along with the per-project options
+            return new ProjectMapping(sourceProject, targetProject, targetProjectName, finalOptions);
+        }
+    }
+}

--- a/src/Unitverse/Helper/SolutionUtilities.cs
+++ b/src/Unitverse/Helper/SolutionUtilities.cs
@@ -10,7 +10,7 @@
 
     public static class SolutionUtilities
     {
-        public static IEnumerable<ProjectItemModel> GetSelectedFiles(DTE2 dte, bool recursive, IGenerationOptions options)
+        public static IEnumerable<ProjectItemModel> GetSupportedFiles(DTE2 dte, bool recursive)
         {
             if (dte == null)
             {
@@ -26,13 +26,13 @@
                 var items = selectedItemObjects.OfType<ProjectItem>().Concat(selectedItemObjects.OfType<Project>().Select(x => x.ProjectItems).SelectMany(x => x.OfType<ProjectItem>()));
 #pragma warning restore VSTHRD010
 
-                return GetSelectedFiles(items, recursive, options);
+                return GetSupportedFiles(items, recursive);
             }
 
             return Enumerable.Empty<ProjectItemModel>();
         }
 
-        private static IEnumerable<ProjectItemModel> GetSelectedFiles(IEnumerable<ProjectItem> items, bool recursive, IGenerationOptions options)
+        private static IEnumerable<ProjectItemModel> GetSupportedFiles(IEnumerable<ProjectItem> items, bool recursive)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -42,7 +42,7 @@
                 {
                     if (recursive)
                     {
-                        foreach (var projectItemSummary in GetSelectedFiles(item.ProjectItems.OfType<ProjectItem>(), true, options))
+                        foreach (var projectItemSummary in GetSupportedFiles(item.ProjectItems.OfType<ProjectItem>(), true))
                         {
                             yield return projectItemSummary;
                         }
@@ -50,7 +50,11 @@
                 }
                 else
                 {
-                    yield return new ProjectItemModel(item, options);
+                    var model = new ProjectItemModel(item);
+                    if (model.IsSupported)
+                    {
+                        yield return model;
+                    }
                 }
             }
         }

--- a/src/Unitverse/Helper/TargetFinder.cs
+++ b/src/Unitverse/Helper/TargetFinder.cs
@@ -11,7 +11,7 @@
 
     internal static class TargetFinder
     {
-        public static FindTargetStatus FindExistingTargetItem(ProjectItemModel source, IGenerationOptions options, out ProjectItem targetItem)
+        public static FindTargetStatus FindExistingTargetItem(ProjectItemModel source, ProjectMapping mapping, out ProjectItem targetItem)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -19,7 +19,7 @@
             var nameParts = VsProjectHelper.GetNameParts(source.Item);
             targetItem = null;
 
-            var targetProject = source.TargetProject;
+            var targetProject = mapping.TargetProject;
             if (targetProject == null)
             {
                 return FindTargetStatus.ProjectNotFound;
@@ -34,7 +34,7 @@
             var extension = Path.GetExtension(source.FilePath);
             var baseName = Path.GetFileNameWithoutExtension(source.FilePath);
 
-            var testFileName = options.GetTargetFileName(baseName);
+            var testFileName = mapping.Options.GenerationOptions.GetTargetFileName(baseName);
             targetItem = targetProjectItems.OfType<ProjectItem>().FirstOrDefault(x => string.Equals(x.Name, testFileName + extension, StringComparison.OrdinalIgnoreCase));
             return targetItem == null ? FindTargetStatus.FileNotFound : FindTargetStatus.Found;
 #pragma warning restore VSTHRD010

--- a/src/Unitverse/UnitTestGeneratorPackage.cs
+++ b/src/Unitverse/UnitTestGeneratorPackage.cs
@@ -1,7 +1,6 @@
 ﻿namespace Unitverse
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;
     using System.Threading;
     using Microsoft.VisualStudio.ComponentModelHost;
@@ -16,7 +15,6 @@
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
     [Guid(Constants.ExtensionGuid)]
-    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideOptionPage(typeof(GenerationOptions), "Unitverse", "Generation Options", 0, 0, true)]
     [ProvideOptionPage(typeof(NamingOptions), "Unitverse", "Naming Options", 0, 0, true)]
@@ -35,9 +33,8 @@
         {
             get
             {
-                var solutionFilePath = Workspace?.CurrentSolution?.FilePath;
                 var statisticsOptions = (StatisticsOptions)GetDialogPage(typeof(StatisticsOptions));
-                return UnitTestGeneratorOptionsFactory.Create(solutionFilePath, GenerationOptions, NamingOptions, StrategyOptions, statisticsOptions.Enabled);
+                return new UnitTestGeneratorOptions(GenerationOptions, NamingOptions, StrategyOptions, statisticsOptions.Enabled);
             }
         }
 

--- a/src/Unitverse/Unitverse.csproj
+++ b/src/Unitverse/Unitverse.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Helper\OutputWindowMessageLogger.cs" />
     <Compile Include="Helper\ProjectMapping.cs" />
     <Compile Include="Helper\ProjectItemModel.cs" />
+    <Compile Include="Helper\ProjectMappingFactory.cs" />
     <Compile Include="Helper\SolutionUtilities.cs" />
     <Compile Include="Helper\StatisticsTracker.cs" />
     <Compile Include="Helper\StatusBarMessageLogger.cs" />


### PR DESCRIPTION
Tidy up and simplification of code around creating project mappings
Ability to have a separate .unitTestGeneratorConfig per-project
First part of addressing #66 