### PR TITLE
Targeting different versions of Roslyn for different VS versions

### DIFF
--- a/src/Unitverse.Core.Tests/Unitverse.Core.Tests.csproj
+++ b/src/Unitverse.Core.Tests/Unitverse.Core.Tests.csproj
@@ -5,6 +5,20 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;SA0001</NoWarn>
+    <VsTargetVersion Condition="'$(VsTargetVersion)' == '' and '$(VisualStudioVersion)' == '17.0' ">VS2022</VsTargetVersion>
+    <VsTargetVersion Condition="'$(VsTargetVersion)' == '' and '$(VisualStudioVersion)' == '16.0' ">VS2019</VsTargetVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(VsTargetVersion)' == 'VS2022'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(VsTargetVersion)' == 'VS2019'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
@@ -12,7 +26,6 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />

--- a/src/Unitverse.Core/Unitverse.Core.csproj
+++ b/src/Unitverse.Core/Unitverse.Core.csproj
@@ -10,12 +10,30 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;SA0001</NoWarn>
+    <VsTargetVersion Condition="'$(VsTargetVersion)' == '' and '$(VisualStudioVersion)' == '17.0' ">VS2022</VsTargetVersion>
+    <VsTargetVersion Condition="'$(VsTargetVersion)' == '' and '$(VisualStudioVersion)' == '16.0' ">VS2019</VsTargetVersion>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(VsTargetVersion)' == 'VS2022'">
+    <DefineConstants>$(DefineConstants);VS2022</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(VsTargetVersion)' == 'VS2019'">
+    <DefineConstants>$(DefineConstants);VS2019</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(VsTargetVersion)' == 'VS2022'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(VsTargetVersion)' == 'VS2019'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="editorconfig" Version="0.12.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Unitverse.ExampleGenerator/Unitverse.ExampleGenerator.csproj
+++ b/src/Unitverse.ExampleGenerator/Unitverse.ExampleGenerator.csproj
@@ -25,6 +25,20 @@
     <ProjectReference Include="..\Unitverse.Core\Unitverse.Core.csproj" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;SA0001</NoWarn>
+    <VsTargetVersion Condition="'$(VsTargetVersion)' == '' and '$(VisualStudioVersion)' == '17.0' ">VS2022</VsTargetVersion>
+    <VsTargetVersion Condition="'$(VsTargetVersion)' == '' and '$(VisualStudioVersion)' == '16.0' ">VS2019</VsTargetVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(VsTargetVersion)' == 'VS2022'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(VsTargetVersion)' == 'VS2019'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
@@ -32,7 +46,6 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />


### PR DESCRIPTION
This PR introduces separate Roslyn versions for VS2019 .v. VS2022. This does introduce the concept that there is one VSIX for each version of Visual Studio - which will be fine if the updated marketplace comes out that allows multiple VSIX files to be listed on a single listing, but may be unworkable otherwise.

Given there hasn't been anyone asking for VS2017, and the next VS version is a couple of years away, the picture should be clearer by the time it becomes an issue.

This PR needs a manual install / build on both VS2019/VS2022 before merging.