### PR TITLE
Fix for mapping method generation with explicit interface implementations

### DIFF
--- a/src/Unitverse.Core.Tests/Resources/MappingMethodList.txt
+++ b/src/Unitverse.Core.Tests/Resources/MappingMethodList.txt
@@ -1,0 +1,17 @@
+namespace TestApp1
+{
+    using System.Collections.Generic;
+
+    public class R
+    {
+        public string Name {get;set;}
+    }
+
+    public class C3
+    {
+        public List<R> Map(List<string> input)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Unitverse.Core.Tests/TestClasses.Designer.cs
+++ b/src/Unitverse.Core.Tests/TestClasses.Designer.cs
@@ -162,15 +162,17 @@ namespace Unitverse.Core.Tests {
         ///
         ///		}
         /// 
-        ///		public abstract int PublicOut(out string s);
+        ///		public abstract int PublicAbstractIn(in string s);
         ///
-        ///		public abstract int PublicRef(ref string s);
+        ///		public abstract int PublicAbstractOut(out string s);
         ///
-        ///		protected abstract int ProtectedOut(out string s);
+        ///		public abstract int PublicAbstractRef(ref string s);
         ///
-        ///		protected abstract int ProtectedRef(ref string s);
-        ///	}
-        ///}.
+        ///		protected abstract int ProtectedAbstractIn(in string s);
+        ///
+        ///		protected abstract int ProtectedAbstractOut(out string s);
+        ///
+        ///		protected abst [rest of string was truncated]&quot;;.
         /// </summary>
         public static string AbstractOutAndRefParams {
             get {
@@ -1118,6 +1120,26 @@ namespace Unitverse.Core.Tests {
         public static string MappingMethod {
             get {
                 return ResourceManager.GetString("MappingMethod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to namespace TestApp1
+        ///{
+        ///    using System.Collections.Generic;
+        ///
+        ///    public class C3
+        ///    {
+        ///        public List&lt;string&gt; Map(List&lt;string&gt; input)
+        ///        {
+        ///            return null;
+        ///        }
+        ///    }
+        ///}.
+        /// </summary>
+        public static string MappingMethodList {
+            get {
+                return ResourceManager.GetString("MappingMethodList", resourceCulture);
             }
         }
         

--- a/src/Unitverse.Core.Tests/TestClasses.resx
+++ b/src/Unitverse.Core.Tests/TestClasses.resx
@@ -229,6 +229,9 @@
   <data name="MappingMethod" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\MappingMethod.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="MappingMethodList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\MappingMethodList.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="MethodWithReservedParamName" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\MethodWithReservedParamName.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.Core/Strategies/MethodGeneration/MappingMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/MappingMethodGenerationStrategy.cs
@@ -79,7 +79,7 @@
 
         private static Dictionary<string, bool> GetProperties(ITypeSymbol returnTypeInfo)
         {
-            var properties = returnTypeInfo.GetMembers().Where(x => x.Kind == SymbolKind.Property).OfType<IPropertySymbol>().Where(x => !x.IsWriteOnly && !x.IsIndexer);
+            var properties = returnTypeInfo.GetMembers().Where(x => x.Kind == SymbolKind.Property).OfType<IPropertySymbol>().Where(x => !x.IsWriteOnly && !x.IsIndexer && x.ExplicitInterfaceImplementations.Length == 0);
 
             var dictionary = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var property in properties)


### PR DESCRIPTION
Fix for mapping method generation attempting to compare explicit interface implementation properties
Addresses #90 