### PR TITLE
Ability to go to target type via type name

### DIFF
--- a/src/Unitverse.Core.Tests/DefaultGenerationOptions.cs
+++ b/src/Unitverse.Core.Tests/DefaultGenerationOptions.cs
@@ -39,5 +39,7 @@
         public UserInterfaceModes UserInterfaceMode => UserInterfaceModes.OnlyWhenControlPressed;
 
         public bool RememberManuallySelectedTargetProjectByDefault => true;
+
+        public FallbackTargetFindingMethod FallbackTargetFinding => FallbackTargetFindingMethod.None;
     }
 }

--- a/src/Unitverse.Core.Tests/Frameworks/FrameworkSetTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/FrameworkSetTests.cs
@@ -1,12 +1,15 @@
 namespace Unitverse.Core.Tests.Frameworks
 {
-    using System;
-    using NSubstitute;
-    using NUnit.Framework;
     using Unitverse.Core.Frameworks;
-    using Unitverse.Core.Helpers;
-    using Unitverse.Core.Options;
+    using System;
+    using NUnit.Framework;
     using FluentAssertions;
+    using NSubstitute;
+    using Unitverse.Core.Models;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis;
+    using Unitverse.Core.Options;
+    using Unitverse.Core.Helpers;
 
     [TestFixture]
     public class FrameworkSetTests
@@ -15,10 +18,9 @@ namespace Unitverse.Core.Tests.Frameworks
         private ITestFramework _testFramework;
         private IMockingFramework _mockingFramework;
         private IAssertionFramework _assertionFramework;
-        private IGenerationContext _context;
-        private string _testTypeNaming;
-        private IUnitTestGeneratorOptions _options;
         private INamingProvider _namingProvider;
+        private IGenerationContext _context;
+        private IUnitTestGeneratorOptions _options;
 
         [SetUp]
         public void SetUp()
@@ -28,61 +30,60 @@ namespace Unitverse.Core.Tests.Frameworks
             _assertionFramework = Substitute.For<IAssertionFramework>();
             _namingProvider = Substitute.For<INamingProvider>();
             _context = Substitute.For<IGenerationContext>();
-            _testTypeNaming = "TestValue455103231";
             _options = Substitute.For<IUnitTestGeneratorOptions>();
-
-            _testClass = new FrameworkSet(_testFramework, _mockingFramework, _assertionFramework, _namingProvider, _context, _testTypeNaming, _options);
+            _testClass = new FrameworkSet(_testFramework, _mockingFramework, _assertionFramework, _namingProvider, _context, _options);
         }
 
         [Test]
         public void CanConstruct()
         {
-            var instance = new FrameworkSet(_testFramework, _mockingFramework, _assertionFramework, _namingProvider, _context, _testTypeNaming, _options);
+            // Act
+            var instance = new FrameworkSet(_testFramework, _mockingFramework, _assertionFramework, _namingProvider, _context, _options);
+            
+            // Assert
             instance.Should().NotBeNull();
         }
 
         [Test]
         public void CannotConstructWithNullTestFramework()
         {
-            FluentActions.Invoking(() => new FrameworkSet(default(ITestFramework), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), "TestValue800970825", Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new FrameworkSet(default(ITestFramework), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotConstructWithNullMockingFramework()
         {
-            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), default(IMockingFramework), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), "TestValue1430299096", Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), default(IMockingFramework), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotConstructWithNullAssertionFramework()
         {
-            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), default(IAssertionFramework), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), "TestValue1900892022", Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), default(IAssertionFramework), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotConstructWithNullNamingProvider()
         {
-            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), default(INamingProvider), Substitute.For<IGenerationContext>(), "TestValue1239307533", Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), default(INamingProvider), Substitute.For<IGenerationContext>(), Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotConstructWithNullContext()
         {
-            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), default(IGenerationContext), "TestValue1680076439", Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("   ")]
-        public void CannotConstructWithInvalidTestTypeNaming(string value)
-        {
-            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), value, Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), default(IGenerationContext), Substitute.For<IUnitTestGeneratorOptions>())).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotConstructWithNullOptions()
         {
-            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), "TestValue969625404", default(IUnitTestGeneratorOptions))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new FrameworkSet(Substitute.For<ITestFramework>(), Substitute.For<IMockingFramework>(), Substitute.For<IAssertionFramework>(), Substitute.For<INamingProvider>(), Substitute.For<IGenerationContext>(), default(IUnitTestGeneratorOptions))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotCallEvaluateTargetModelWithNullClassModel()
+        {
+            FluentActions.Invoking(() => _testClass.EvaluateTargetModel(default(ClassModel))).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
@@ -104,21 +105,15 @@ namespace Unitverse.Core.Tests.Frameworks
         }
 
         [Test]
-        public void ContextIsInitializedCorrectly()
-        {
-            _testClass.Context.Should().BeSameAs(_context);
-        }
-
-        [Test]
-        public void TestTypeNamingIsInitializedCorrectly()
-        {
-            _testClass.TestTypeNaming.Should().BeSameAs(_testTypeNaming);
-        }
-
-        [Test]
         public void NamingProviderIsInitializedCorrectly()
         {
             _testClass.NamingProvider.Should().BeSameAs(_namingProvider);
+        }
+
+        [Test]
+        public void ContextIsInitializedCorrectly()
+        {
+            _testClass.Context.Should().BeSameAs(_context);
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Frameworks/FrameworkSetTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/FrameworkSetTests.cs
@@ -81,12 +81,6 @@ namespace Unitverse.Core.Tests.Frameworks
         }
 
         [Test]
-        public void CannotCallEvaluateTargetModelWithNullClassModel()
-        {
-            FluentActions.Invoking(() => _testClass.EvaluateTargetModel(default(ClassModel))).Should().Throw<ArgumentNullException>();
-        }
-
-        [Test]
         public void TestFrameworkIsInitializedCorrectly()
         {
             _testClass.TestFramework.Should().BeSameAs(_testFramework);

--- a/src/Unitverse.Core.Tests/Helpers/DetectedGenerationOptionsTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/DetectedGenerationOptionsTests.cs
@@ -99,5 +99,105 @@ namespace Unitverse.Core.Tests.Helpers
             _baseOptions.TestTypeNaming.Returns("5252532");
             Assert.That(instance.TestTypeNaming, Is.EqualTo("5252532"));
         }
+
+        [Test]
+        public void CanGetEmitUsingsOutsideNamespace()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.EmitUsingsOutsideNamespace.Returns(true);
+            Assert.That(instance.EmitUsingsOutsideNamespace, Is.EqualTo(true));
+            _baseOptions.EmitUsingsOutsideNamespace.Returns(false);
+            Assert.That(instance.EmitUsingsOutsideNamespace, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void CanGetEmitTestsForInternals()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.EmitTestsForInternals.Returns(true);
+            Assert.That(instance.EmitTestsForInternals, Is.EqualTo(true));
+            _baseOptions.EmitTestsForInternals.Returns(false);
+            Assert.That(instance.EmitTestsForInternals, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void CanGetPartialGenerationAllowed()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.EmitTestsForInternals.Returns(true);
+            Assert.That(instance.PartialGenerationAllowed, Is.EqualTo(true));
+            _baseOptions.EmitTestsForInternals.Returns(false);
+            Assert.That(instance.PartialGenerationAllowed, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void CanGetEmitSubclassForProtectedMethods()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.EmitSubclassForProtectedMethods.Returns(true);
+            Assert.That(instance.EmitSubclassForProtectedMethods, Is.EqualTo(true));
+            _baseOptions.EmitSubclassForProtectedMethods.Returns(false);
+            Assert.That(instance.EmitSubclassForProtectedMethods, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void CanGetAutomaticallyConfigureMocks()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.AutomaticallyConfigureMocks.Returns(true);
+            Assert.That(instance.AutomaticallyConfigureMocks, Is.EqualTo(true));
+            _baseOptions.AutomaticallyConfigureMocks.Returns(false);
+            Assert.That(instance.AutomaticallyConfigureMocks, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void CanGetArrangeComment()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.ArrangeComment.Returns("ArrangeYo");
+            Assert.That(instance.ArrangeComment, Is.EqualTo("ArrangeYo"));
+        }
+
+        [Test]
+        public void CanGetActComment()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.ActComment.Returns("ActYo");
+            Assert.That(instance.ActComment, Is.EqualTo("ActYo"));
+        }
+
+        [Test]
+        public void CanGetAssertComment()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.AssertComment.Returns("AssertYo");
+            Assert.That(instance.AssertComment, Is.EqualTo("AssertYo"));
+        }
+
+        [Test]
+        public void CanGetUserInterfaceMode()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.UserInterfaceMode.Returns(UserInterfaceModes.OnlyWhenControlPressed);
+            Assert.That(instance.UserInterfaceMode, Is.EqualTo(UserInterfaceModes.OnlyWhenControlPressed));
+        }
+
+        [Test]
+        public void CanGetRememberManuallySelectedTargetProjectByDefault()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.RememberManuallySelectedTargetProjectByDefault.Returns(true);
+            Assert.That(instance.RememberManuallySelectedTargetProjectByDefault, Is.EqualTo(true));
+            _baseOptions.RememberManuallySelectedTargetProjectByDefault.Returns(false);
+            Assert.That(instance.RememberManuallySelectedTargetProjectByDefault, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void CanGetFallbackTargetFinding()
+        {
+            var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
+            _baseOptions.FallbackTargetFinding.Returns(FallbackTargetFindingMethod.TypeInAnyNamespace);
+            Assert.That(instance.FallbackTargetFinding, Is.EqualTo(FallbackTargetFindingMethod.TypeInAnyNamespace));
+        }
     }
 }

--- a/src/Unitverse.Core.Tests/Helpers/DetectedGenerationOptionsTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/DetectedGenerationOptionsTests.cs
@@ -124,9 +124,9 @@ namespace Unitverse.Core.Tests.Helpers
         public void CanGetPartialGenerationAllowed()
         {
             var instance = new DetectedGenerationOptions(_baseOptions, null, null, null);
-            _baseOptions.EmitTestsForInternals.Returns(true);
+            _baseOptions.PartialGenerationAllowed.Returns(true);
             Assert.That(instance.PartialGenerationAllowed, Is.EqualTo(true));
-            _baseOptions.EmitTestsForInternals.Returns(false);
+            _baseOptions.PartialGenerationAllowed.Returns(false);
             Assert.That(instance.PartialGenerationAllowed, Is.EqualTo(false));
         }
 

--- a/src/Unitverse.Core.Tests/Helpers/TargetNameTransformTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/TargetNameTransformTests.cs
@@ -79,9 +79,9 @@ namespace Unitverse.Core.Tests.Helpers
         public static void CanCallGetTargetTypeName()
         {
             var frameworkSet = Substitute.For<IFrameworkSet>();
-            frameworkSet.TestTypeNaming.Returns("{0}Tests");
+            frameworkSet.Options.GenerationOptions.TestTypeNaming.Returns("{0}Tests");
             var classModel = ClassModelProvider.Instance;
-            var result = frameworkSet.GetTargetTypeName(classModel, false);
+            var result = frameworkSet.GetTargetTypeName(classModel);
             Assert.That(result, Is.EqualTo(ClassModelProvider.Instance.ClassName + "Tests"));
         }
 
@@ -89,22 +89,22 @@ namespace Unitverse.Core.Tests.Helpers
         public static void CanCallGetTargetTypeNameWithGenericDisambiguation()
         {
             var frameworkSet = Substitute.For<IFrameworkSet>();
-            frameworkSet.TestTypeNaming.Returns("{0}Tests");
+            frameworkSet.Options.GenerationOptions.TestTypeNaming.Returns("{0}Tests");
             var classModel = ClassModelProvider.GenericInstance;
-            var result = frameworkSet.GetTargetTypeName(classModel, true);
+            var result = frameworkSet.GetTargetTypeName(classModel);
             Assert.That(result, Is.EqualTo(ClassModelProvider.GenericInstance.ClassName + "_1Tests"));
         }
 
         [Test]
         public static void CannotCallGetTargetTypeNameWithNullFrameworkSet()
         {
-            Assert.Throws<ArgumentNullException>(() => default(IFrameworkSet).GetTargetTypeName(ClassModelProvider.Instance, false));
+            Assert.Throws<ArgumentNullException>(() => default(IFrameworkSet).GetTargetTypeName(ClassModelProvider.Instance));
         }
 
         [Test]
         public static void CannotCallGetTargetTypeNameWithNullClassModel()
         {
-            Assert.Throws<ArgumentNullException>(() => Substitute.For<IFrameworkSet>().GetTargetTypeName(default(ClassModel), false));
+            Assert.Throws<ArgumentNullException>(() => Substitute.For<IFrameworkSet>().GetTargetTypeName(default(ClassModel)));
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Models/TypeSymbolProviderTests.cs
+++ b/src/Unitverse.Core.Tests/Models/TypeSymbolProviderTests.cs
@@ -1,0 +1,55 @@
+namespace Unitverse.Core.Tests.Models
+{
+    using Unitverse.Core.Models;
+    using System;
+    using NUnit.Framework;
+    using FluentAssertions;
+    using NSubstitute;
+    using Microsoft.CodeAnalysis;
+
+    [TestFixture]
+    public class TypeSymbolProviderTests
+    {
+        private TypeSymbolProvider _testClass;
+        private INamedTypeSymbol _typeSymbol;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _typeSymbol = Substitute.For<INamedTypeSymbol>();
+            _testClass = new TypeSymbolProvider(_typeSymbol);
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            // Act
+            var instance = new TypeSymbolProvider(_typeSymbol);
+            
+            // Assert
+            instance.Should().NotBeNull();
+        }
+
+        [Test]
+        public void CannotConstructWithNullTypeSymbol()
+        {
+            FluentActions.Invoking(() => new TypeSymbolProvider(default(INamedTypeSymbol))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CanGetClassName()
+        {
+            // Arrange
+            _typeSymbol.Name.Returns("foo");
+
+            // Assert
+            _testClass.ClassName.Should().Be("foo");
+        }
+
+        [Test]
+        public void TypeSymbolIsInitializedCorrectly()
+        {
+            _testClass.TypeSymbol.Should().BeSameAs(_typeSymbol);
+        }
+    }
+}

--- a/src/Unitverse.Core.Tests/Options/Editing/GenerationOptions.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/GenerationOptions.cs
@@ -100,5 +100,10 @@
         [Description("Whether to pre-select the check box in the user interface that controls whether the target project should be remembered for the session")]
         [ExcludedFromUserInterface]
         public bool RememberManuallySelectedTargetProjectByDefault { get; set; } = true;
+
+        [Category("Naming")]
+        [DisplayName("Fallback type finding method")]
+        [Description("The method to use when finding tests by the file name does not work")]
+        public FallbackTargetFindingMethod FallbackTargetFinding { get; set; } = FallbackTargetFindingMethod.TypeInCorrectNamespace;
     }
 }

--- a/src/Unitverse.Core.Tests/Options/MutableGenerationOptionsTests.cs
+++ b/src/Unitverse.Core.Tests/Options/MutableGenerationOptionsTests.cs
@@ -31,6 +31,16 @@ namespace Unitverse.Core.Tests.Options
             _options.UseFluentAssertions.Returns(true);
             _options.EmitUsingsOutsideNamespace.Returns(true);
             _options.AutoDetectFrameworkTypes.Returns(false);
+            _options.PartialGenerationAllowed.Returns(true);
+            _options.EmitTestsForInternals.Returns(true);
+            _options.EmitSubclassForProtectedMethods.Returns(true);
+            _options.AutomaticallyConfigureMocks.Returns(true);
+            _options.ArrangeComment.Returns("Arr");
+            _options.ActComment.Returns("Act");
+            _options.AssertComment.Returns("Assert");
+            _options.UserInterfaceMode.Returns(UserInterfaceModes.Always);
+            _options.RememberManuallySelectedTargetProjectByDefault.Returns(true);
+            _options.FallbackTargetFinding.Returns(FallbackTargetFindingMethod.TypeInAnyNamespace);
 
             _testClass = new MutableGenerationOptions(_options);
             Assert.That(_testClass.FrameworkType, Is.EqualTo(_options.FrameworkType));
@@ -42,6 +52,16 @@ namespace Unitverse.Core.Tests.Options
             Assert.That(_testClass.UseFluentAssertions, Is.EqualTo(_options.UseFluentAssertions));
             Assert.That(_testClass.EmitUsingsOutsideNamespace, Is.EqualTo(_options.EmitUsingsOutsideNamespace));
             Assert.That(_testClass.AutoDetectFrameworkTypes, Is.EqualTo(_options.AutoDetectFrameworkTypes));
+            Assert.That(_testClass.PartialGenerationAllowed, Is.EqualTo(_options.PartialGenerationAllowed));
+            Assert.That(_testClass.EmitTestsForInternals, Is.EqualTo(_options.EmitTestsForInternals));
+            Assert.That(_testClass.EmitSubclassForProtectedMethods, Is.EqualTo(_options.EmitSubclassForProtectedMethods));
+            Assert.That(_testClass.AutomaticallyConfigureMocks, Is.EqualTo(_options.AutomaticallyConfigureMocks));
+            Assert.That(_testClass.ArrangeComment, Is.EqualTo(_options.ArrangeComment));
+            Assert.That(_testClass.ActComment, Is.EqualTo(_options.ActComment));
+            Assert.That(_testClass.AssertComment, Is.EqualTo(_options.AssertComment));
+            Assert.That(_testClass.UserInterfaceMode, Is.EqualTo(_options.UserInterfaceMode));
+            Assert.That(_testClass.RememberManuallySelectedTargetProjectByDefault, Is.EqualTo(_options.RememberManuallySelectedTargetProjectByDefault));
+            Assert.That(_testClass.FallbackTargetFinding, Is.EqualTo(_options.FallbackTargetFinding));
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/ComparableGenerationStrategyTests.cs
+++ b/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/ComparableGenerationStrategyTests.cs
@@ -26,7 +26,9 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
 
             var options = Substitute.For<INamingOptions>();
             options.ImplementsIComparableNamingPattern.Returns("ImplementsIComparable{0}");
-            _frameworkSet = new FrameworkSet(new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>()), new NSubstituteMockingFramework(generationContext), new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>()), new NamingProvider(options), generationContext, "{0}Tests", Substitute.For<IUnitTestGeneratorOptions>());
+            var fullOptions = Substitute.For<IUnitTestGeneratorOptions>();
+            fullOptions.GenerationOptions.TestTypeNaming.Returns("{0}Tests");
+            _frameworkSet = new FrameworkSet(new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>()), new NSubstituteMockingFramework(generationContext), new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>()), new NamingProvider(options), generationContext, fullOptions);
             _testClass = new ComparableGenerationStrategy(_frameworkSet);
         }
 

--- a/src/Unitverse.Core/CoreGenerator.cs
+++ b/src/Unitverse.Core/CoreGenerator.cs
@@ -311,7 +311,7 @@
 
         private static TypeDeclarationSyntax EnsureAllConstructorParametersHaveFields(IFrameworkSet frameworkSet, ClassModel classModel, TypeDeclarationSyntax targetType)
         {
-            var setupMethod = frameworkSet.TestFramework.CreateSetupMethod(frameworkSet.GetTargetTypeName(classModel, true));
+            var setupMethod = frameworkSet.TestFramework.CreateSetupMethod(frameworkSet.GetTargetTypeName(classModel));
 
             BaseMethodDeclarationSyntax foundMethod = null, updatedMethod = null;
             if (setupMethod is MethodDeclarationSyntax methodSyntax)
@@ -480,14 +480,8 @@
             {
                 var types = TestableItemExtractor.GetTypeDeclarations(targetNamespace);
 
-                var targetClassName = frameworkSet.GetTargetTypeName(classModel, true);
+                var targetClassName = frameworkSet.GetTargetTypeName(classModel);
                 originalTargetType = targetType = types.FirstOrDefault(x => string.Equals(x.GetClassName(), targetClassName, StringComparison.OrdinalIgnoreCase));
-
-                if (originalTargetType == null)
-                {
-                    targetClassName = frameworkSet.GetTargetTypeName(classModel, false);
-                    originalTargetType = targetType = types.FirstOrDefault(x => string.Equals(x.GetClassName(), targetClassName, StringComparison.OrdinalIgnoreCase));
-                }
             }
 
             if (targetType == null)

--- a/src/Unitverse.Core/Frameworks/FrameworkSet.cs
+++ b/src/Unitverse.Core/Frameworks/FrameworkSet.cs
@@ -7,19 +7,13 @@
 
     public class FrameworkSet : IFrameworkSet
     {
-        public FrameworkSet(ITestFramework testFramework, IMockingFramework mockingFramework, IAssertionFramework assertionFramework, INamingProvider namingProvider, IGenerationContext context, string testTypeNaming, IUnitTestGeneratorOptions options)
+        public FrameworkSet(ITestFramework testFramework, IMockingFramework mockingFramework, IAssertionFramework assertionFramework, INamingProvider namingProvider, IGenerationContext context, IUnitTestGeneratorOptions options)
         {
-            if (string.IsNullOrWhiteSpace(testTypeNaming))
-            {
-                throw new ArgumentNullException(nameof(testTypeNaming));
-            }
-
             TestFramework = testFramework ?? throw new ArgumentNullException(nameof(testFramework));
             MockingFramework = mockingFramework ?? throw new ArgumentNullException(nameof(mockingFramework));
             AssertionFramework = assertionFramework ?? throw new ArgumentNullException(nameof(assertionFramework));
             NamingProvider = namingProvider ?? throw new ArgumentNullException(nameof(namingProvider));
             Context = context ?? throw new ArgumentNullException(nameof(context));
-            TestTypeNaming = testTypeNaming;
             Options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
@@ -32,8 +26,6 @@
         public INamingProvider NamingProvider { get; }
 
         public IGenerationContext Context { get; private set; }
-
-        public string TestTypeNaming { get; }
 
         public IUnitTestGeneratorOptions Options { get; }
 

--- a/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
+++ b/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
@@ -20,7 +20,7 @@
             var context = new GenerationContext();
             var testFramework = CreateTestFramework(options);
             IAssertionFramework assertionFramework = testFramework;
-            return new FrameworkSet(testFramework, Create(options.GenerationOptions.MockingFrameworkType, context), options.GenerationOptions.UseFluentAssertions ? new FluentAssertionFramework(assertionFramework) : assertionFramework, new NamingProvider(options.NamingOptions), context, options.GenerationOptions.TestTypeNaming, options);
+            return new FrameworkSet(testFramework, Create(options.GenerationOptions.MockingFrameworkType, context), options.GenerationOptions.UseFluentAssertions ? new FluentAssertionFramework(assertionFramework) : assertionFramework, new NamingProvider(options.NamingOptions), context, options);
         }
 
         private static IMockingFramework Create(MockingFrameworkType mockingFrameworkType, IGenerationContext context)

--- a/src/Unitverse.Core/Frameworks/IFrameworkSet.cs
+++ b/src/Unitverse.Core/Frameworks/IFrameworkSet.cs
@@ -16,7 +16,5 @@
         INamingProvider NamingProvider { get; }
 
         IGenerationContext Context { get; }
-
-        string TestTypeNaming { get; }
     }
 }

--- a/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
+++ b/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
@@ -52,5 +52,7 @@
         public UserInterfaceModes UserInterfaceMode => _baseOptions.UserInterfaceMode;
 
         public bool RememberManuallySelectedTargetProjectByDefault => _baseOptions.RememberManuallySelectedTargetProjectByDefault;
+
+        public FallbackTargetFindingMethod FallbackTargetFinding => _baseOptions.FallbackTargetFinding;
     }
 }

--- a/src/Unitverse.Core/Helpers/TargetNameTransform.cs
+++ b/src/Unitverse.Core/Helpers/TargetNameTransform.cs
@@ -55,6 +55,11 @@
 
         public static string GetTargetTypeName(this IFrameworkSet frameworkSet, ITypeSymbolProvider classModel)
         {
+            if (frameworkSet is null)
+            {
+                throw new ArgumentNullException(nameof(frameworkSet));
+            }
+
             return frameworkSet.Options.GenerationOptions.GetTargetTypeName(classModel);
         }
 

--- a/src/Unitverse.Core/Helpers/TargetNameTransform.cs
+++ b/src/Unitverse.Core/Helpers/TargetNameTransform.cs
@@ -53,11 +53,16 @@
             }
         }
 
-        public static string GetTargetTypeName(this IFrameworkSet frameworkSet, ClassModel classModel, bool withGenericDisambiguation)
+        public static string GetTargetTypeName(this IFrameworkSet frameworkSet, ITypeSymbolProvider classModel)
         {
-            if (frameworkSet == null)
+            return frameworkSet.Options.GenerationOptions.GetTargetTypeName(classModel);
+        }
+
+        public static string GetTargetTypeName(this IGenerationOptions options, ITypeSymbolProvider classModel)
+        {
+            if (options == null)
             {
-                throw new ArgumentNullException(nameof(frameworkSet));
+                throw new ArgumentNullException(nameof(options));
             }
 
             if (classModel == null)
@@ -68,17 +73,26 @@
             try
             {
                 var sourceName = classModel.ClassName;
-                if (withGenericDisambiguation && classModel.TypeSymbol?.TypeParameters.Length > 0)
+                if (classModel.TypeSymbol?.TypeParameters.Length > 0)
                 {
                     sourceName += "_" + classModel.TypeSymbol.TypeParameters.Length;
                 }
 
-                return string.Format(CultureInfo.CurrentCulture, frameworkSet.TestTypeNaming, sourceName);
+                return string.Format(CultureInfo.CurrentCulture, options.TestTypeNaming, sourceName);
             }
             catch (FormatException)
             {
                 throw new InvalidOperationException(Strings.TargetNameTransform_GetTargetTypeName_Cannot_not_derive_target_type_name__please_check_the_test_type_naming_setting_);
             }
+        }
+
+        public static string GetFullyQualifiedTargetTypeName(this IGenerationOptions options, ITypeSymbolProvider classModel, Func<string, string> transform)
+        {
+            var symbol = options.GetTargetTypeName(classModel);
+
+            var transformed = transform(classModel.TypeSymbol.ContainingNamespace.ToFullName());
+
+            return transformed + "." + symbol;
         }
     }
 }

--- a/src/Unitverse.Core/Helpers/TypeInfoExtensions.cs
+++ b/src/Unitverse.Core/Helpers/TypeInfoExtensions.cs
@@ -19,7 +19,7 @@
             return GetLastNamePart(name);
         }
 
-        public static string ToFullName(this ITypeSymbol symbol)
+        public static string ToFullName(this ISymbol symbol)
         {
             if (symbol == null)
             {

--- a/src/Unitverse.Core/Models/ClassModel.cs
+++ b/src/Unitverse.Core/Models/ClassModel.cs
@@ -12,7 +12,7 @@
     using Unitverse.Core.Helpers;
     using Unitverse.Core.Options;
 
-    public class ClassModel
+    public class ClassModel : ITypeSymbolProvider
     {
         public ClassModel(TypeDeclarationSyntax declaration, SemanticModel semanticModel, bool isSingleItem)
         {

--- a/src/Unitverse.Core/Models/ITypeSymbolProvider.cs
+++ b/src/Unitverse.Core/Models/ITypeSymbolProvider.cs
@@ -1,0 +1,11 @@
+﻿namespace Unitverse.Core.Models
+{
+    using Microsoft.CodeAnalysis;
+
+    public interface ITypeSymbolProvider
+    {
+        string ClassName { get; }
+
+        INamedTypeSymbol TypeSymbol { get; }
+    }
+}

--- a/src/Unitverse.Core/Models/TypeSymbolProvider.cs
+++ b/src/Unitverse.Core/Models/TypeSymbolProvider.cs
@@ -1,0 +1,16 @@
+﻿namespace Unitverse.Core.Models
+{
+    using Microsoft.CodeAnalysis;
+
+    public class TypeSymbolProvider : ITypeSymbolProvider
+    {
+        public TypeSymbolProvider(INamedTypeSymbol typeSymbol)
+        {
+            TypeSymbol = typeSymbol ?? throw new System.ArgumentNullException(nameof(typeSymbol));
+        }
+
+        public string ClassName => TypeSymbol.Name;
+
+        public INamedTypeSymbol TypeSymbol { get; }
+    }
+}

--- a/src/Unitverse.Core/Options/FallbackTargetFindingMethod.cs
+++ b/src/Unitverse.Core/Options/FallbackTargetFindingMethod.cs
@@ -1,0 +1,16 @@
+﻿namespace Unitverse.Core.Options
+{
+    using System.ComponentModel;
+
+    public enum FallbackTargetFindingMethod
+    {
+        [Description("None")]
+        None = 0,
+
+        [Description("Find the correct type name in any namespace")]
+        TypeInAnyNamespace,
+
+        [Description("Find the correct type name in the correct namespace")]
+        TypeInCorrectNamespace,
+    }
+}

--- a/src/Unitverse.Core/Options/IGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/IGenerationOptions.cs
@@ -37,5 +37,7 @@
         UserInterfaceModes UserInterfaceMode { get; }
 
         bool RememberManuallySelectedTargetProjectByDefault { get; }
+
+        FallbackTargetFindingMethod FallbackTargetFinding { get; }
     }
 }

--- a/src/Unitverse.Core/Options/MutableGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/MutableGenerationOptions.cs
@@ -29,6 +29,7 @@
             AssertComment = options.AssertComment;
             UserInterfaceMode = options.UserInterfaceMode;
             RememberManuallySelectedTargetProjectByDefault = options.RememberManuallySelectedTargetProjectByDefault;
+            FallbackTargetFinding = options.FallbackTargetFinding;
         }
 
         public TestFrameworkTypes FrameworkType { get; set; }
@@ -66,5 +67,7 @@
         public UserInterfaceModes UserInterfaceMode { get; set; }
 
         public bool RememberManuallySelectedTargetProjectByDefault { get; set; }
+
+        public FallbackTargetFindingMethod FallbackTargetFinding { get; set; }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
@@ -49,7 +49,7 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var targetTypeName = _frameworkSet.GetTargetTypeName(model, true);
+            var targetTypeName = _frameworkSet.GetTargetTypeName(model);
             var classDeclaration = SyntaxFactory.ClassDeclaration(targetTypeName);
 
             classDeclaration = classDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));

--- a/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
@@ -48,7 +48,7 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var targetTypeName = _frameworkSet.GetTargetTypeName(model, true);
+            var targetTypeName = _frameworkSet.GetTargetTypeName(model);
             var classDeclaration = SyntaxFactory.ClassDeclaration(targetTypeName);
 
             classDeclaration = classDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));

--- a/src/Unitverse.Core/Strategies/ClassGeneration/StaticClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/StaticClassGenerationStrategy.cs
@@ -36,7 +36,7 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var classDeclaration = SyntaxFactory.ClassDeclaration(_frameworkSet.GetTargetTypeName(model, true));
+            var classDeclaration = SyntaxFactory.ClassDeclaration(_frameworkSet.GetTargetTypeName(model));
 
             model.TargetInstance = model.TypeSyntax;
 

--- a/src/Unitverse.ExampleGenerator/DefaultGenerationOptions.cs
+++ b/src/Unitverse.ExampleGenerator/DefaultGenerationOptions.cs
@@ -39,5 +39,7 @@
         public UserInterfaceModes UserInterfaceMode => UserInterfaceModes.OnlyWhenControlPressed;
 
         public bool RememberManuallySelectedTargetProjectByDefault => true;
+
+        public FallbackTargetFindingMethod FallbackTargetFinding => FallbackTargetFindingMethod.None;
     }
 }

--- a/src/Unitverse.Specs/GenerationOptions.cs
+++ b/src/Unitverse.Specs/GenerationOptions.cs
@@ -48,5 +48,7 @@
         public UserInterfaceModes UserInterfaceMode => UserInterfaceModes.OnlyWhenControlPressed;
 
         public bool RememberManuallySelectedTargetProjectByDefault => true;
+
+        public FallbackTargetFindingMethod FallbackTargetFinding => FallbackTargetFindingMethod.None;
     }
 }

--- a/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
+++ b/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
@@ -147,7 +147,7 @@
                 {
                     var projectItem = source.Item;
 
-                    if (!withRegeneration && !mapping.Options.GenerationOptions.PartialGenerationAllowed && TargetFinder.FindExistingTargetItem(source, mapping, out _) == FindTargetStatus.Found)
+                    if (!withRegeneration && !mapping.Options.GenerationOptions.PartialGenerationAllowed && TargetFinder.FindExistingTargetItem(null, source, mapping, _package, messageLogger, out _) == FindTargetStatus.Found)
                     {
                         if (isSingleCreation)
                         {

--- a/src/Unitverse/Commands/GenerationItem.cs
+++ b/src/Unitverse/Commands/GenerationItem.cs
@@ -42,7 +42,8 @@
 
         public ProjectItemModel Source { get; }
         public ProjectMapping Mapping { get; }
-        public SyntaxNode SourceSymbol { get; set; }
+        public ISymbol SourceSymbol { get; set; }
+        public SyntaxNode SourceNode { get; set; }
 
         public string TargetContent { get; set; }
 

--- a/src/Unitverse/Commands/GoToUnitTestsCommand.cs
+++ b/src/Unitverse/Commands/GoToUnitTestsCommand.cs
@@ -91,7 +91,10 @@
                         throw new InvalidOperationException("Cannot go to tests for this item because no supported files were found");
                     }
 
-                    GoToTestsHelper.FindTestsFor(source, _package);
+                    var logger = new AggregateLogger();
+                    logger.Initialize();
+
+                    GoToTestsHelper.FindTestsFor(null, source, _package, logger);
                 }, _package);
         }
     }

--- a/src/Unitverse/Helper/GoToTestsHelper.cs
+++ b/src/Unitverse/Helper/GoToTestsHelper.cs
@@ -1,27 +1,24 @@
-﻿using Microsoft.VisualStudio.Shell;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.Shell;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Unitverse.Helper
 {
     public static class GoToTestsHelper
     {
-        public static void FindTestsFor(ProjectItemModel source, IUnitTestGeneratorPackage package)
+        public static void FindTestsFor(ISymbol symbol, ProjectItemModel source, IUnitTestGeneratorPackage package, AggregateLogger logger)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, false);
 
-            var status = TargetFinder.FindExistingTargetItem(source, mapping, out var targetItem);
+            var status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out var targetItem);
 
             // retry the find without taking into account manually selected mappings if we didn't find it
             if (status != FindTargetStatus.Found)
             {
                 mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, true);
-                status = TargetFinder.FindExistingTargetItem(source, mapping, out targetItem);
+                status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out targetItem);
             }
 
             switch (status)

--- a/src/Unitverse/Helper/TextViewHelper.cs
+++ b/src/Unitverse/Helper/TextViewHelper.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Unitverse.Helper
+{
+    internal static class TextViewHelper
+    {
+        internal static IWpfTextView GetTextView(IServiceProvider serviceProvider)
+        {
+            var textManager = (IVsTextManager)serviceProvider.GetService(typeof(SVsTextManager));
+            if (textManager != null)
+            {
+                textManager.GetActiveView(1, null, out var textView);
+
+                var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
+                var adapterService = componentModel?.GetService<Microsoft.VisualStudio.Editor.IVsEditorAdaptersFactoryService>();
+
+                return adapterService?.GetWpfTextView(textView);
+            }
+
+            return null;
+        }
+
+        internal static async Task<Tuple<SyntaxNode, ISymbol, TypeInfo>> GetTargetSymbolAsync(ITextView textView)
+        {
+            var caretPosition = textView.Caret.Position.BufferPosition;
+
+            var document = caretPosition.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
+            if (document != null)
+            {
+                var syntaxNode = await document.GetSyntaxRootAsync().ConfigureAwait(true);
+                var semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(true);
+
+                var syntaxToken = syntaxNode.FindToken(caretPosition).Parent;
+
+                if (syntaxToken != null)
+                {
+                    var declaration =
+                        syntaxToken.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().FirstOrDefault() ??
+                        syntaxToken.AncestorsAndSelf().OfType<PropertyDeclarationSyntax>().FirstOrDefault() ??
+                        syntaxToken.AncestorsAndSelf().OfType<ConstructorDeclarationSyntax>().FirstOrDefault() ??
+                        syntaxToken.AncestorsAndSelf().OfType<IndexerDeclarationSyntax>().FirstOrDefault() ??
+                        syntaxToken as RecordDeclarationSyntax ??
+                        syntaxToken as StructDeclarationSyntax ??
+                        syntaxToken as ClassDeclarationSyntax as SyntaxNode;
+
+                    if (declaration != null)
+                    {
+                        return Tuple.Create(declaration, semanticModel.GetDeclaredSymbol(declaration), default(TypeInfo));
+                    }
+
+                    if (syntaxToken.Parent is BaseTypeSyntax)
+                    {
+                        var symbol = semanticModel.GetTypeInfo(syntaxToken);
+                        return Tuple.Create(syntaxToken, default(ISymbol), symbol);
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Unitverse/Options/GenerationOptions.cs
+++ b/src/Unitverse/Options/GenerationOptions.cs
@@ -102,5 +102,10 @@
         [Description("Whether to pre-select the check box in the user interface that controls whether the target project should be remembered for the session")]
         [ExcludedFromUserInterface]
         public bool RememberManuallySelectedTargetProjectByDefault { get; set; } = true;
+
+        [Category("Naming")]
+        [DisplayName("Fallback type finding method")]
+        [Description("The method to use when finding tests by the file name does not work")]
+        public FallbackTargetFindingMethod FallbackTargetFinding { get; set; } = FallbackTargetFindingMethod.TypeInCorrectNamespace;
     }
 }

--- a/src/Unitverse/Unitverse.csproj
+++ b/src/Unitverse/Unitverse.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Helper\ProjectItemModel.cs" />
     <Compile Include="Helper\ProjectMappingFactory.cs" />
     <Compile Include="Helper\SolutionUtilities.cs" />
+    <Compile Include="Helper\TextViewHelper.cs" />
     <Compile Include="Helper\ZoomTracker.cs" />
     <Compile Include="Helper\StatisticsTracker.cs" />
     <Compile Include="Helper\StatusBarMessageLogger.cs" />


### PR DESCRIPTION
Addresses #96 

Adds the ability to navigate to tests via the type name, rather than just the file name.

Requires final manual test before merge.