### PR TITLE
Config source visibility

### DIFF
--- a/src/Unitverse.Core.Tests/Helpers/AssignmentValueHelperTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/AssignmentValueHelperTests.cs
@@ -50,7 +50,7 @@ namespace Unitverse.Core.Tests.Helpers
             generationOptions.FrameworkType.Returns(TestFrameworkTypes.NUnit3);
             generationOptions.MockingFrameworkType.Returns(MockingFrameworkType.NSubstitute);
             generationOptions.TestTypeNaming.Returns("{0}Tests");
-            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), new DefaultStrategyOptions(), false);
+            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), new DefaultStrategyOptions(), false, new Dictionary<string, string>());
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             var visitedTypes = new HashSet<string>();

--- a/src/Unitverse.Core.Tests/Options/Editing/BooleanEditableItemTests.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/BooleanEditableItemTests.cs
@@ -23,14 +23,14 @@ namespace Unitverse.Core.Tests.Options.Editing
             _fieldName = "TestValue1029729535";
             _value = false;
             _setValue = x => { };
-            _testClass = new BooleanEditableItem(_text, _description, _fieldName, _value, _setValue);
+            _testClass = new BooleanEditableItem(_text, _description, _fieldName, _value, _setValue, false, null);
         }
 
         [Test]
         public void CanConstruct()
         {
             // Act
-            var instance = new BooleanEditableItem(_text, _description, _fieldName, _value, _setValue);
+            var instance = new BooleanEditableItem(_text, _description, _fieldName, _value, _setValue, false, null);
             
             // Assert
             instance.Should().NotBeNull();
@@ -39,7 +39,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [Test]
         public void CannotConstructWithNullSetValue()
         {
-            FluentActions.Invoking(() => new BooleanEditableItem("TestValue26046281", "TestValue994223939", "TestValue1320835479", false, default(Action<bool>))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new BooleanEditableItem("TestValue26046281", "TestValue994223939", "TestValue1320835479", false, default(Action<bool>), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -47,7 +47,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidText(string value)
         {
-            FluentActions.Invoking(() => new BooleanEditableItem(value, "TestValue972041960", "TestValue1741199683", false, x => { })).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new BooleanEditableItem(value, "TestValue972041960", "TestValue1741199683", false, x => { }, false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -55,7 +55,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidDescription(string value)
         {
-            FluentActions.Invoking(() => new BooleanEditableItem("TestValue331535449", value, "TestValue1221071621", true, x => { })).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new BooleanEditableItem("TestValue331535449", value, "TestValue1221071621", true, x => { }, false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -63,7 +63,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidFieldName(string value)
         {
-            FluentActions.Invoking(() => new BooleanEditableItem("TestValue770458689", "TestValue2127094014", value, false, x => { })).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new BooleanEditableItem("TestValue770458689", "TestValue2127094014", value, false, x => { }, false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Options/Editing/DisplayItemTests.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/DisplayItemTests.cs
@@ -10,7 +10,7 @@ namespace Unitverse.Core.Tests.Options.Editing
     {
         private class TestDisplayItem : DisplayItem
         {
-            public TestDisplayItem(string text) : base(text)
+            public TestDisplayItem(string text, bool showSourceIcon, string sourceFileName) : base(text, showSourceIcon, sourceFileName)
             {
             }
 
@@ -29,14 +29,14 @@ namespace Unitverse.Core.Tests.Options.Editing
         public void SetUp()
         {
             _text = "TestValue1727859796";
-            _testClass = new TestDisplayItem(_text);
+            _testClass = new TestDisplayItem(_text, false, null);
         }
 
         [Test]
         public void CanConstruct()
         {
             // Act
-            var instance = new TestDisplayItem(_text);
+            var instance = new TestDisplayItem(_text, false, null);
             
             // Assert
             instance.Should().NotBeNull();
@@ -47,7 +47,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidText(string value)
         {
-            FluentActions.Invoking(() => new TestDisplayItem(value)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new TestDisplayItem(value, false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
@@ -81,10 +81,30 @@ namespace Unitverse.Core.Tests.Options.Editing
         }
 
         [Test]
+        public void ShowVsConfigSourceIsInitializedCorrectly()
+        {
+            _testClass.ShowVsConfigSource.Should().Be(false);
+            _testClass = new TestDisplayItem(_text, true, null);
+            _testClass.ShowVsConfigSource.Should().Be(true);
+            _testClass = new TestDisplayItem(_text, true, "someFile.Dat");
+            _testClass.ShowVsConfigSource.Should().Be(false);
+        }
+
+        [Test]
+        public void ShowFileConfigSourceeIsInitializedCorrectly()
+        {
+            _testClass.ShowFileConfigSource.Should().Be(false);
+            _testClass = new TestDisplayItem(_text, true, null);
+            _testClass.ShowFileConfigSource.Should().Be(false);
+            _testClass = new TestDisplayItem(_text, true, "someFile.Dat");
+            _testClass.ShowFileConfigSource.Should().Be(true);
+        }
+
+        [Test]
         public void DoubleAmpersandInTextIsReplaced()
         {
             _text = "Something && Something Else";
-            _testClass = new TestDisplayItem(_text);
+            _testClass = new TestDisplayItem(_text, false, null);
             _testClass.Text.Should().Be("Something & Something Else");
         }
     }

--- a/src/Unitverse.Core.Tests/Options/Editing/EditableItemExtractorTests.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/EditableItemExtractorTests.cs
@@ -20,7 +20,7 @@ namespace Unitverse.Core.Tests.Options.Editing
             var modifiableSource = new MutableGenerationOptions(source);
 
             // Act
-            var result = EditableItemExtractor.ExtractFrom(source, modifiableSource, withSkipping).ToList();
+            var result = EditableItemExtractor.ExtractFrom(source, modifiableSource, withSkipping, str => str == nameof(IGenerationOptions.ArrangeComment) ? "file" : null).ToList();
 
             // Assert
             result.Should().Contain(x => x.ItemType == EditableItemType.String && x.Text == "Act block comment" && x is StringEditableItem && ((StringEditableItem)x).Description == "The comment to leave before any act statements (leave blank to suppress)" && ((StringEditableItem)x).Value == "freddo");
@@ -44,6 +44,14 @@ namespace Unitverse.Core.Tests.Options.Editing
                 if (property.PropertyType == typeof(string))
                 {
                     result.Should().Contain(x => x.ItemType == EditableItemType.String && x is EditableItem && ((EditableItem)x).FieldName == propertyName, propertyName);
+                    if (propertyName == nameof(IGenerationOptions.ArrangeComment))
+                    {
+                        result.OfType<StringEditableItem>().First(x => x.FieldName == propertyName).SourceFileName.Should().Be("file");
+                    }
+                    else
+                    {
+                        result.OfType<StringEditableItem>().First(x => x.FieldName == propertyName).SourceFileName.Should().BeNull();
+                    }
                 }
                 else if (property.PropertyType == typeof(bool))
                 {

--- a/src/Unitverse.Core.Tests/Options/Editing/EditableItemTests.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/EditableItemTests.cs
@@ -10,7 +10,7 @@ namespace Unitverse.Core.Tests.Options.Editing
     {
         private class TestEditableItem : EditableItem
         {
-            public TestEditableItem(string text, string description, string fieldName) : base(text, description, fieldName)
+            public TestEditableItem(string text, string description, string fieldName) : base(text, description, fieldName, false, null)
             {
             }
 

--- a/src/Unitverse.Core.Tests/Options/Editing/EnumEditableItemTests.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/EnumEditableItemTests.cs
@@ -34,14 +34,14 @@ namespace Unitverse.Core.Tests.Options.Editing
             _value = new object();
             _setValue = x => { };
             _enumerationType = typeof(TestEnum);
-            _testClass = new EnumEditableItem(_text, _description, _fieldName, _value, _setValue, _enumerationType);
+            _testClass = new EnumEditableItem(_text, _description, _fieldName, _value, _setValue, _enumerationType, false, null);
         }
 
         [Test]
         public void CanConstruct()
         {
             // Act
-            var instance = new EnumEditableItem(_text, _description, _fieldName, _value, _setValue, _enumerationType);
+            var instance = new EnumEditableItem(_text, _description, _fieldName, _value, _setValue, _enumerationType, false, null);
             
             // Assert
             instance.Should().NotBeNull();
@@ -50,13 +50,13 @@ namespace Unitverse.Core.Tests.Options.Editing
         [Test]
         public void CannotConstructWithNullSetValue()
         {
-            FluentActions.Invoking(() => new EnumEditableItem("TestValue910415667", "TestValue1550196320", "TestValue1171641232", new object(), default(Action<object>), Type.GetType("TestValue1525999670"))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem("TestValue910415667", "TestValue1550196320", "TestValue1171641232", new object(), default(Action<object>), typeof(string), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotConstructWithNullEnumerationType()
         {
-            FluentActions.Invoking(() => new EnumEditableItem("TestValue168000583", "TestValue397121609", "TestValue1525245590", new object(), x => { }, default(Type))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem("TestValue168000583", "TestValue397121609", "TestValue1525245590", new object(), x => { }, default(Type), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -64,7 +64,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidText(string value)
         {
-            FluentActions.Invoking(() => new EnumEditableItem(value, "TestValue349423377", "TestValue628294131", new object(), x => { }, Type.GetType("TestValue253676871"))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem(value, "TestValue349423377", "TestValue628294131", new object(), x => { }, typeof(string), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -72,7 +72,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidDescription(string value)
         {
-            FluentActions.Invoking(() => new EnumEditableItem("TestValue764192942", value, "TestValue743926900", new object(), x => { }, Type.GetType("TestValue82070851"))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem("TestValue764192942", value, "TestValue743926900", new object(), x => { }, typeof(string), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -80,7 +80,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidFieldName(string value)
         {
-            FluentActions.Invoking(() => new EnumEditableItem("TestValue1822449456", "TestValue386046142", value, new object(), x => { }, Type.GetType("TestValue731434616"))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem("TestValue1822449456", "TestValue386046142", value, new object(), x => { }, typeof(string), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Options/Editing/EnumEditableItemTests.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/EnumEditableItemTests.cs
@@ -50,7 +50,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [Test]
         public void CannotConstructWithNullSetValue()
         {
-            FluentActions.Invoking(() => new EnumEditableItem("TestValue910415667", "TestValue1550196320", "TestValue1171641232", new object(), default(Action<object>), typeof(string), false, null)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem("TestValue910415667", "TestValue1550196320", "TestValue1171641232", new object(), default(Action<object>), typeof(TestEnum), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidText(string value)
         {
-            FluentActions.Invoking(() => new EnumEditableItem(value, "TestValue349423377", "TestValue628294131", new object(), x => { }, typeof(string), false, null)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem(value, "TestValue349423377", "TestValue628294131", new object(), x => { }, typeof(TestEnum), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -72,7 +72,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidDescription(string value)
         {
-            FluentActions.Invoking(() => new EnumEditableItem("TestValue764192942", value, "TestValue743926900", new object(), x => { }, typeof(string), false, null)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem("TestValue764192942", value, "TestValue743926900", new object(), x => { }, typeof(TestEnum), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -80,7 +80,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidFieldName(string value)
         {
-            FluentActions.Invoking(() => new EnumEditableItem("TestValue1822449456", "TestValue386046142", value, new object(), x => { }, typeof(string), false, null)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new EnumEditableItem("TestValue1822449456", "TestValue386046142", value, new object(), x => { }, typeof(TestEnum), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Options/Editing/StringEditableItemTests.cs
+++ b/src/Unitverse.Core.Tests/Options/Editing/StringEditableItemTests.cs
@@ -23,14 +23,14 @@ namespace Unitverse.Core.Tests.Options.Editing
             _fieldName = "TestValue2012998739";
             _value = "TestValue219560791";
             _setValue = x => { };
-            _testClass = new StringEditableItem(_text, _description, _fieldName, _value, _setValue);
+            _testClass = new StringEditableItem(_text, _description, _fieldName, _value, _setValue, false, null);
         }
 
         [Test]
         public void CanConstruct()
         {
             // Act
-            var instance = new StringEditableItem(_text, _description, _fieldName, _value, _setValue);
+            var instance = new StringEditableItem(_text, _description, _fieldName, _value, _setValue, false, null);
             
             // Assert
             instance.Should().NotBeNull();
@@ -39,7 +39,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [Test]
         public void CannotConstructWithNullSetValue()
         {
-            FluentActions.Invoking(() => new StringEditableItem("TestValue531486156", "TestValue1498720570", "TestValue1541340860", "TestValue1026239667", default(Action<string>))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new StringEditableItem("TestValue531486156", "TestValue1498720570", "TestValue1541340860", "TestValue1026239667", default(Action<string>), false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -47,7 +47,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidText(string value)
         {
-            FluentActions.Invoking(() => new StringEditableItem(value, "TestValue1906171625", "TestValue1704187850", "TestValue96324715", x => { })).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new StringEditableItem(value, "TestValue1906171625", "TestValue1704187850", "TestValue96324715", x => { }, false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -55,7 +55,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidDescription(string value)
         {
-            FluentActions.Invoking(() => new StringEditableItem("TestValue1878384096", value, "TestValue1737143007", "TestValue817444129", x => { })).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new StringEditableItem("TestValue1878384096", value, "TestValue1737143007", "TestValue817444129", x => { }, false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -63,7 +63,7 @@ namespace Unitverse.Core.Tests.Options.Editing
         [TestCase("   ")]
         public void CannotConstructWithInvalidFieldName(string value)
         {
-            FluentActions.Invoking(() => new StringEditableItem("TestValue1985423896", "TestValue1184592193", value, "TestValue1512639607", x => { })).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new StringEditableItem("TestValue1985423896", "TestValue1184592193", value, "TestValue1512639607", x => { }, false, null)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Options/EditorConfigFieldMapperTests.cs
+++ b/src/Unitverse.Core.Tests/Options/EditorConfigFieldMapperTests.cs
@@ -5,6 +5,9 @@ namespace Unitverse.Core.Tests.Options
     using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Options;
+    using FluentAssertions;
+    using System.Reflection;
+    using System.Linq;
 
     [TestFixture]
     public static class EditorConfigFieldMapperTests
@@ -29,6 +32,22 @@ namespace Unitverse.Core.Tests.Options
         public static void CannotCallApplyToWithNullTarget()
         {
             Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>().ApplyTo(default(MutableGenerationOptions)));
+        }
+
+        [Test]
+        public static void CanCallCreateMutatorSet()
+        {
+            // Act
+            var result = EditorConfigFieldMapper.CreateMutatorSet<MutableGenerationOptions>();
+            var second = EditorConfigFieldMapper.CreateMutatorSet<MutableGenerationOptions>();
+
+            // Assert
+            foreach (var member in typeof(MutableGenerationOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.CanWrite))
+            {
+                result.Should().ContainKey(member.Name);
+            }
+
+            second.Should().BeSameAs(result);
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Options/TypeMemberMutatorTests.cs
+++ b/src/Unitverse.Core.Tests/Options/TypeMemberMutatorTests.cs
@@ -18,37 +18,14 @@ namespace Unitverse.Core.Tests.Options
             public int TargetInt { get; set; }
         }
 
-        private TypeMemberMutator _testClass;
-        private Type _targetType;
-
-        [SetUp]
-        public void SetUp()
-        {
-            _targetType = typeof(Target);
-            _testClass = new TypeMemberMutator(_targetType);
-        }
-
-        [Test]
-        public void CanConstruct()
-        {
-            var instance = new TypeMemberMutator(_targetType);
-            Assert.That(instance, Is.Not.Null);
-        }
-
-        [Test]
-        public void CannotConstructWithNullTargetType()
-        {
-            Assert.Throws<ArgumentNullException>(() => new TypeMemberMutator(default(Type)));
-        }
-
         [Test]
         public void CanCallSet()
         {
             var instance = new Target();
-            _testClass.Set(instance, nameof(Target.FrameworkType), nameof(TestFrameworkTypes.MsTest));
-            _testClass.Set(instance, nameof(Target.TargetGuid), "F371CA3F-3330-4975-9E13-2580CDDC89CD");
-            _testClass.Set(instance, nameof(Target.TargetString), "someString");
-            _testClass.Set(instance, nameof(Target.TargetInt), "13241");
+            TypeMemberMutator.Set(instance, typeof(Target).GetProperty(nameof(Target.FrameworkType)), nameof(TestFrameworkTypes.MsTest));
+            TypeMemberMutator.Set(instance, typeof(Target).GetProperty(nameof(Target.TargetGuid)), "F371CA3F-3330-4975-9E13-2580CDDC89CD");
+            TypeMemberMutator.Set(instance, typeof(Target).GetProperty(nameof(Target.TargetString)), "someString");
+            TypeMemberMutator.Set(instance, typeof(Target).GetProperty(nameof(Target.TargetInt)), "13241");
             Assert.That(instance.FrameworkType, Is.EqualTo(TestFrameworkTypes.MsTest));
             Assert.That(instance.TargetGuid, Is.EqualTo(new Guid("F371CA3F-3330-4975-9E13-2580CDDC89CD")));
             Assert.That(instance.TargetString, Is.EqualTo("someString"));
@@ -58,15 +35,13 @@ namespace Unitverse.Core.Tests.Options
         [Test]
         public void CannotCallSetWithNullInstance()
         {
-            Assert.Throws<ArgumentNullException>(() => _testClass.Set(default(object), "TestValue901544463", "TestValue570844002"));
+            Assert.Throws<ArgumentNullException>(() => TypeMemberMutator.Set(default(object), typeof(Target).GetProperty(nameof(Target.FrameworkType)), "TestValue570844002"));
         }
 
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("   ")]
-        public void CanCallSetWithInvalidFieldName(string value)
+        [Test]
+        public void CanCallSetWithNullMember()
         {
-            Assert.DoesNotThrow(() => _testClass.Set(new object(), value, "TestValue325869245"));
+            Assert.DoesNotThrow(() => TypeMemberMutator.Set(new object(), null, "TestValue325869245"));
         }
 
         [TestCase(null)]
@@ -74,7 +49,7 @@ namespace Unitverse.Core.Tests.Options
         [TestCase("   ")]
         public void CanCallSetWithInvalidFieldValue(string value)
         {
-            Assert.DoesNotThrow(() => _testClass.Set(new object(), "TestValue606729554", value));
+            Assert.DoesNotThrow(() => TypeMemberMutator.Set(new object(), typeof(Target).GetProperty(nameof(Target.FrameworkType)), value));
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Options/TypeMemberMutatorTests.cs
+++ b/src/Unitverse.Core.Tests/Options/TypeMemberMutatorTests.cs
@@ -39,9 +39,9 @@ namespace Unitverse.Core.Tests.Options
         }
 
         [Test]
-        public void CanCallSetWithNullMember()
+        public void CannotCallSetWithNullMember()
         {
-            Assert.DoesNotThrow(() => TypeMemberMutator.Set(new object(), null, "TestValue325869245"));
+            Assert.Throws<ArgumentNullException>(() => TypeMemberMutator.Set(new object(), null, "TestValue325869245"));
         }
 
         [TestCase(null)]

--- a/src/Unitverse.Core.Tests/Options/UnitTestGeneratorOptionsFactoryTests.cs
+++ b/src/Unitverse.Core.Tests/Options/UnitTestGeneratorOptionsFactoryTests.cs
@@ -72,6 +72,9 @@ namespace Unitverse.Core.Tests.Options
                 var result = UnitTestGeneratorOptionsFactory.Create(solutionFilePath, generationOptions, namingOptions, strategyOptions, false);
                 Assert.That(result.GenerationOptions.FrameworkType, Is.EqualTo(TestFrameworkTypes.NUnit2));
                 Assert.That(result.GenerationOptions.MockingFrameworkType, Is.EqualTo(MockingFrameworkType.NSubstitute));
+
+                Assert.That(result.GetFieldSourceFileName(nameof(IGenerationOptions.FrameworkType)), Is.EqualTo(Path.Combine(pathC, CoreConstants.ConfigFileName)));
+                Assert.That(result.GetFieldSourceFileName(nameof(IGenerationOptions.MockingFrameworkType)), Is.Null);
             }
             finally
             {

--- a/src/Unitverse.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
+++ b/src/Unitverse.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
@@ -61,7 +61,7 @@ namespace Unitverse.Core.Tests.Strategies.ValueGeneration
             generationOptions.FrameworkType.Returns(TestFrameworkTypes.NUnit3);
             generationOptions.MockingFrameworkType.Returns(MockingFrameworkType.NSubstitute);
             generationOptions.TestTypeNaming.Returns("{0}Tests");
-            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), new DefaultStrategyOptions(), false);
+            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), new DefaultStrategyOptions(), false, new Dictionary<string, string>());
             var frameworkSet = FrameworkSetFactory.Create(options);
             var expression = ValueGenerationStrategyFactory.GenerateFor(info, model, new HashSet<string>(StringComparer.OrdinalIgnoreCase),  frameworkSet);
 

--- a/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
+++ b/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
@@ -164,7 +164,7 @@
             generationOptions.MockingFrameworkType = mockingFrameworkType;
             generationOptions.UseFluentAssertions = useFluentAssertions;
 
-            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false);
+            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false, new Dictionary<string, string>());
 
             var lines = classAsText.Lines().Where(x => x.StartsWith("// #", StringComparison.Ordinal)).Select(x => x.Substring(4).Trim()).ToList();
             if (lines.Any())

--- a/src/Unitverse.Core/Options/Editing/BooleanEditableItem.cs
+++ b/src/Unitverse.Core/Options/Editing/BooleanEditableItem.cs
@@ -4,8 +4,8 @@
 
     public class BooleanEditableItem : EditableItem
     {
-        public BooleanEditableItem(string text, string description, string fieldName, bool value, Action<bool> setValue)
-            : base(text, description, fieldName)
+        public BooleanEditableItem(string text, string description, string fieldName, bool value, Action<bool> setValue, bool showSourceIcon, string sourceFileName)
+            : base(text, description, fieldName, showSourceIcon, sourceFileName)
         {
             _value = value;
             _setValue = setValue ?? throw new ArgumentNullException(nameof(setValue));

--- a/src/Unitverse.Core/Options/Editing/DisplayItem.cs
+++ b/src/Unitverse.Core/Options/Editing/DisplayItem.cs
@@ -5,7 +5,7 @@
 
     public abstract class DisplayItem : INotifyPropertyChanged
     {
-        public DisplayItem(string text)
+        protected DisplayItem(string text, bool showSourceIcon, string sourceFileName)
         {
             if (string.IsNullOrWhiteSpace(text))
             {
@@ -13,7 +13,34 @@
             }
 
             Text = text.Replace("&&", "&");
+            SourceFileName = sourceFileName;
+            if (showSourceIcon)
+            {
+                ShowVsConfigSource = string.IsNullOrWhiteSpace(sourceFileName);
+                ShowFileConfigSource = !ShowVsConfigSource;
+            }
         }
+
+        public void SetSourceState(bool showAutoDetectionSource, bool showVsConfigSource)
+        {
+            if (ShowVsConfigSource || ShowFileConfigSource || ShowAutoDetectionSource)
+            {
+                ShowAutoDetectionSource = showAutoDetectionSource;
+                ShowVsConfigSource = showVsConfigSource && !showAutoDetectionSource;
+                ShowFileConfigSource = !showVsConfigSource && !showAutoDetectionSource;
+                RaisePropertyChanged(nameof(ShowAutoDetectionSource));
+                RaisePropertyChanged(nameof(ShowVsConfigSource));
+                RaisePropertyChanged(nameof(ShowFileConfigSource));
+            }
+        }
+
+        public bool ShowVsConfigSource { get; private set; }
+
+        public bool ShowFileConfigSource { get; private set; }
+
+        public bool ShowAutoDetectionSource { get; private set; }
+
+        public string SourceFileName { get; }
 
         public abstract EditableItemType ItemType { get; }
 

--- a/src/Unitverse.Core/Options/Editing/EditableItem.cs
+++ b/src/Unitverse.Core/Options/Editing/EditableItem.cs
@@ -5,8 +5,8 @@
 
     public abstract class EditableItem : DisplayItem
     {
-        public EditableItem(string text, string description, string fieldName)
-            : base(text)
+        public EditableItem(string text, string description, string fieldName, bool showSourceIcon, string sourceFileName)
+            : base(text, showSourceIcon, sourceFileName)
         {
             if (string.IsNullOrWhiteSpace(description))
             {

--- a/src/Unitverse.Core/Options/Editing/EditableItemExtractor.cs
+++ b/src/Unitverse.Core/Options/Editing/EditableItemExtractor.cs
@@ -8,7 +8,7 @@
 
     public static class EditableItemExtractor
     {
-        public static IEnumerable<DisplayItem> ExtractFrom(object source, object modifiableInstance, bool skipExcluded)
+        public static IEnumerable<DisplayItem> ExtractFrom(object source, object modifiableInstance, bool skipExcluded, Func<string, string> sourceFileExtractor = null)
         {
             if (source is null)
             {
@@ -47,23 +47,26 @@
                     var text = GetAttribute<DisplayNameAttribute>(property)?.DisplayName ?? property.Name;
                     var description = GetAttribute<DescriptionAttribute>(property)?.Description ?? property.Name;
 
+                    var shouldShowSource = sourceFileExtractor != null;
+                    var sourceFile = sourceFileExtractor?.Invoke(property.Name);
+
                     if (propertyType == typeof(string))
                     {
                         var value = (string)modifiableProperty.GetValue(modifiableInstance, null);
                         Action<string> setValue = s => modifiableProperty.SetValue(modifiableInstance, s, null);
-                        list.Add(new StringEditableItem(text, description, modifiableProperty.Name, value, setValue));
+                        list.Add(new StringEditableItem(text, description, modifiableProperty.Name, value, setValue, shouldShowSource, sourceFile));
                     }
                     else if (propertyType == typeof(bool))
                     {
                         var value = (bool)modifiableProperty.GetValue(modifiableInstance, null);
                         Action<bool> setValue = b => modifiableProperty.SetValue(modifiableInstance, b, null);
-                        list.Add(new BooleanEditableItem(text, description, modifiableProperty.Name, value, setValue));
+                        list.Add(new BooleanEditableItem(text, description, modifiableProperty.Name, value, setValue, shouldShowSource, sourceFile));
                     }
                     else if (propertyType.IsEnum)
                     {
                         var value = modifiableProperty.GetValue(modifiableInstance, null);
                         Action<object> setValue = o => modifiableProperty.SetValue(modifiableInstance, o, null);
-                        list.Add(new EnumEditableItem(text, description, modifiableProperty.Name, value, setValue, propertyType));
+                        list.Add(new EnumEditableItem(text, description, modifiableProperty.Name, value, setValue, propertyType, shouldShowSource, sourceFile));
                     }
                     else
                     {

--- a/src/Unitverse.Core/Options/Editing/EnumEditableItem.cs
+++ b/src/Unitverse.Core/Options/Editing/EnumEditableItem.cs
@@ -6,8 +6,8 @@
 
     public class EnumEditableItem : EditableItem
     {
-        public EnumEditableItem(string text, string description, string fieldName, object value, Action<object> setValue, Type enumerationType)
-            : base(text, description, fieldName)
+        public EnumEditableItem(string text, string description, string fieldName, object value, Action<object> setValue, Type enumerationType, bool showSourceIcon, string sourceFileName)
+            : base(text, description, fieldName, showSourceIcon, sourceFileName)
         {
             var selectedValueName = value.ToString();
 

--- a/src/Unitverse.Core/Options/Editing/HeaderDisplayItem.cs
+++ b/src/Unitverse.Core/Options/Editing/HeaderDisplayItem.cs
@@ -3,7 +3,7 @@
     public class HeaderDisplayItem : DisplayItem
     {
         public HeaderDisplayItem(string text)
-            : base(text)
+            : base(text, false, null)
         {
         }
 

--- a/src/Unitverse.Core/Options/Editing/StringEditableItem.cs
+++ b/src/Unitverse.Core/Options/Editing/StringEditableItem.cs
@@ -4,8 +4,8 @@
 
     public class StringEditableItem : EditableItem
     {
-        public StringEditableItem(string text, string description, string fieldName, string value, Action<string> setValue)
-            : base(text, description, fieldName)
+        public StringEditableItem(string text, string description, string fieldName, string value, Action<string> setValue, bool showSourceIcon, string sourceFileName)
+            : base(text, description, fieldName, showSourceIcon, sourceFileName)
         {
             _value = value;
             _setValue = setValue ?? throw new ArgumentNullException(nameof(setValue));

--- a/src/Unitverse.Core/Options/EditorConfigFieldMapper.cs
+++ b/src/Unitverse.Core/Options/EditorConfigFieldMapper.cs
@@ -2,26 +2,53 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
 
     public static class EditorConfigFieldMapper
     {
-        public static void ApplyTo<T>(this Dictionary<string, string> fileConfiguration, T target)
+        private static readonly Dictionary<Type, Dictionary<string, TypeMemberSetter>> Cache = new Dictionary<Type, Dictionary<string, TypeMemberSetter>>();
+
+        public static Dictionary<string, TypeMemberSetter> CreateMutatorSet<T>()
+        {
+            if (Cache.TryGetValue(typeof(T), out var mutatorSet))
+            {
+                return mutatorSet;
+            }
+
+            mutatorSet = new Dictionary<string, TypeMemberSetter>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var member in typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.CanWrite))
+            {
+                TypeMemberSetter setter = (instance, value) => TypeMemberMutator.Set(instance, member, value);
+                mutatorSet[member.Name] = setter;
+            }
+
+            Cache[typeof(T)] = mutatorSet;
+            return mutatorSet;
+        }
+
+        public static void ApplyTo<T>(this Dictionary<string, string> values, T instance)
             where T : class
         {
-            if (fileConfiguration == null)
+            if (values is null)
             {
-                throw new ArgumentNullException(nameof(fileConfiguration));
+                throw new ArgumentNullException(nameof(values));
             }
 
-            if (target == null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(target));
+                throw new ArgumentNullException(nameof(instance));
             }
 
-            var mutator = new TypeMemberMutator(typeof(T));
-            foreach (var property in fileConfiguration)
+            var mutatorSet = CreateMutatorSet<T>();
+            foreach (var valuePair in values)
             {
-                mutator.Set(target, property.Key, property.Value);
+                var cleanFieldName = valuePair.Key.Replace("_", string.Empty).Replace("-", string.Empty);
+                if (mutatorSet.TryGetValue(cleanFieldName, out var mutator))
+                {
+                    mutator(instance, valuePair.Value);
+                }
             }
         }
     }

--- a/src/Unitverse.Core/Options/IUnitTestGeneratorOptions.cs
+++ b/src/Unitverse.Core/Options/IUnitTestGeneratorOptions.cs
@@ -1,7 +1,11 @@
 ﻿namespace Unitverse.Core.Options
 {
+    using System.Collections.Generic;
+
     public interface IUnitTestGeneratorOptions
     {
+        string GetFieldSourceFileName(string fieldName);
+
         bool StatisticsCollectionEnabled { get; }
 
         IGenerationOptions GenerationOptions { get; }
@@ -9,5 +13,7 @@
         INamingOptions NamingOptions { get; }
 
         IStrategyOptions StrategyOptions { get; }
+
+        IEnumerable<KeyValuePair<string, int>> SourceCounts { get; }
     }
 }

--- a/src/Unitverse.Core/Options/UnitTestGeneratorOptions.cs
+++ b/src/Unitverse.Core/Options/UnitTestGeneratorOptions.cs
@@ -1,15 +1,20 @@
 ﻿namespace Unitverse.Core.Options
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     public class UnitTestGeneratorOptions : IUnitTestGeneratorOptions
     {
-        public UnitTestGeneratorOptions(IGenerationOptions generationOptions, INamingOptions namingOptions, IStrategyOptions strategyOptions, bool statisticsCollectionEnabled)
+        private readonly Dictionary<string, string> _membersSetByFilename;
+
+        public UnitTestGeneratorOptions(IGenerationOptions generationOptions, INamingOptions namingOptions, IStrategyOptions strategyOptions, bool statisticsCollectionEnabled, Dictionary<string, string> membersSetByFilename)
         {
             GenerationOptions = generationOptions ?? throw new ArgumentNullException(nameof(generationOptions));
             NamingOptions = namingOptions ?? throw new ArgumentNullException(nameof(namingOptions));
             StrategyOptions = strategyOptions ?? throw new ArgumentNullException(nameof(strategyOptions));
             StatisticsCollectionEnabled = statisticsCollectionEnabled;
+            _membersSetByFilename = membersSetByFilename ?? throw new ArgumentNullException(nameof(membersSetByFilename));
         }
 
         public IGenerationOptions GenerationOptions { get; }
@@ -19,5 +24,22 @@
         public IStrategyOptions StrategyOptions { get; }
 
         public bool StatisticsCollectionEnabled { get; }
+
+        public IEnumerable<KeyValuePair<string, int>> SourceCounts => _membersSetByFilename.GroupBy(x => x.Value).Select(x => new KeyValuePair<string, int>(x.Key, x.Count()));
+
+        public string GetFieldSourceFileName(string fieldName)
+        {
+            if (string.IsNullOrWhiteSpace(fieldName))
+            {
+                throw new ArgumentNullException(nameof(fieldName));
+            }
+
+            if (_membersSetByFilename.TryGetValue(fieldName, out var value))
+            {
+                return value;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Unitverse.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
+++ b/src/Unitverse.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
@@ -53,6 +53,7 @@
                 new SimpleValueGenerationStrategy(() => (Random.Next(int.MaxValue) % 2) > 0 ? Generate.Literal(true) : Generate.Literal(false), "bool", "bool?"),
                 new SimpleValueGenerationStrategy(() => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName("CultureInfo"), SyntaxFactory.IdentifierName((Random.Next(int.MaxValue) % 2) > 0 ? "CurrentCulture" : "InvariantCulture")), "System.Globalization.CultureInfo"),
                 new SimpleValueGenerationStrategy(() => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName("CancellationToken"), SyntaxFactory.IdentifierName("None")), "System.Threading.CancellationToken"),
+                new SimpleValueGenerationStrategy(() => SyntaxFactory.TypeOfExpression(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword))), "System.Type"),
                 new SimpleValueGenerationStrategy(ArrayFactory.Byte, "byte[]"),
                 new TypedValueGenerationStrategy(EnumFactory.Random, "System.Enum"),
                 new SimpleValueGenerationStrategy(() => Generate.ObjectCreation(SyntaxFactory.IdentifierName("DefaultHttpContext")), "Microsoft.AspNetCore.Http.HttpContext"),

--- a/src/Unitverse.ExampleGenerator/Program.cs
+++ b/src/Unitverse.ExampleGenerator/Program.cs
@@ -108,7 +108,8 @@ namespace Unitverse.ExampleGenerator
             var namingOptions = new MutableNamingOptions(new DefaultNamingOptions());
             var strategyOptions = new MutableStrategyOptions(new DefaultStrategyOptions());
 
-            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false);
+            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false, new Dictionary<string, string>());
+
 
             var lines = classAsText.Lines().Where(x => x.StartsWith("// #", StringComparison.Ordinal)).Select(x => x.Substring(4).Trim()).ToList();
             if (lines.Any())

--- a/src/Unitverse.Specs/BaseSteps.cs
+++ b/src/Unitverse.Specs/BaseSteps.cs
@@ -6,6 +6,7 @@
     using Unitverse.Core.Helpers;
     using Unitverse.Core.Options;
     using TechTalk.SpecFlow;
+    using System.Collections.Generic;
 
     [Binding]
     public class BaseSteps
@@ -26,7 +27,7 @@
             _context.SemanticModel = model;
 
             var extractor = new TestableItemExtractor(syntaxTree, model);
-            _context.ClassModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First(), new UnitTestGeneratorOptions(new GenerationOptions(TestFrameworkTypes.NUnit3, MockingFrameworkType.NSubstitute), new DefaultNamingOptions(), new DefaultStrategyOptions(), false)).First();
+            _context.ClassModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First(), new UnitTestGeneratorOptions(new GenerationOptions(TestFrameworkTypes.NUnit3, MockingFrameworkType.NSubstitute), new DefaultNamingOptions(), new DefaultStrategyOptions(), false, new Dictionary<string, string>())).First();
         }
 
         [Given(@"I set my test framework to '(.*)'")]

--- a/src/Unitverse.Specs/GenerationOptions.cs
+++ b/src/Unitverse.Specs/GenerationOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace Unitverse.Specs
 {
+    using System.Collections.Generic;
     using Unitverse.Core.Options;
 
     // ENHANCE - add fluent assertions to specs
@@ -13,7 +14,7 @@
 
         public static IUnitTestGeneratorOptions Get(TestFrameworkTypes testFramework, MockingFrameworkType mockFramework)
         {
-            return new UnitTestGeneratorOptions(new GenerationOptions(testFramework, mockFramework), new DefaultNamingOptions(), new DefaultStrategyOptions(), false);
+            return new UnitTestGeneratorOptions(new GenerationOptions(testFramework, mockFramework), new DefaultNamingOptions(), new DefaultStrategyOptions(), false, new Dictionary<string, string>());
         }
 
         public TestFrameworkTypes FrameworkType { get; }

--- a/src/Unitverse/Commands/GenerateTestForSymbolCommand.cs
+++ b/src/Unitverse/Commands/GenerateTestForSymbolCommand.cs
@@ -166,7 +166,7 @@
                 messageLogger.Initialize();
 
                 var source = new ProjectItemModel(VsProjectHelper.GetProjectItem(document.FilePath));
-                var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, _package.Options, true, false);
+                var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, _package.Options, true, false, messageLogger);
                 if (mapping == null)
                 {
                     return;

--- a/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
+++ b/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
@@ -132,7 +132,7 @@
                     throw new InvalidOperationException("Cannot generate unit tests for multiple projects at the same time, please select a single project");
                 }
 
-                var mapping = ProjectMappingFactory.CreateMappingFor(sourceProjects.Single(), baseOptions, true, false);
+                var mapping = ProjectMappingFactory.CreateMappingFor(sourceProjects.Single(), baseOptions, true, false, messageLogger);
                 if (mapping == null)
                 {
                     return;

--- a/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
+++ b/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
@@ -147,7 +147,8 @@
                 {
                     var projectItem = source.Item;
 
-                    if (!withRegeneration && !mapping.Options.GenerationOptions.PartialGenerationAllowed && TargetFinder.FindExistingTargetItem(null, source, mapping, _package, messageLogger, out _) == FindTargetStatus.Found)
+                    var targetItemStatus = TargetFinder.FindExistingTargetItem(null, source, mapping, _package, messageLogger, out var foundTarget, out var wasRedirection);
+                    if (!withRegeneration && !mapping.Options.GenerationOptions.PartialGenerationAllowed && targetItemStatus == FindTargetStatus.Found)
                     {
                         if (isSingleCreation)
                         {
@@ -160,7 +161,13 @@
                         continue;
                     }
 
-                    generationItems.Add(new GenerationItem(source, mapping));
+                    var item = new GenerationItem(source, mapping);
+                    if (foundTarget != null && wasRedirection)
+                    {
+                        item.OverrideTargetFileName = Path.GetFileName(foundTarget.Name);
+                    }
+
+                    generationItems.Add(item);
                 }
 
                 if (generationItems.Any())

--- a/src/Unitverse/Commands/GenerationItem.cs
+++ b/src/Unitverse/Commands/GenerationItem.cs
@@ -47,11 +47,13 @@
 
         public string TargetContent { get; set; }
 
+        public string OverrideTargetFileName { get; set; }
+
         public string TargetFileName
         {
             get
             {
-                var targetFileName = Mapping.Options.GenerationOptions.GetTargetFileName(Path.GetFileNameWithoutExtension(Source.FilePath)) + Path.GetExtension(Source.FilePath);
+                var targetFileName = OverrideTargetFileName ?? Mapping.Options.GenerationOptions.GetTargetFileName(Path.GetFileNameWithoutExtension(Source.FilePath)) + Path.GetExtension(Source.FilePath);
                 if (string.IsNullOrEmpty(_targetPath))
                 {
                     return targetFileName;

--- a/src/Unitverse/Helper/CodeGenerator.cs
+++ b/src/Unitverse/Helper/CodeGenerator.cs
@@ -111,7 +111,7 @@
         private static void AddTargetItem(IUnitTestGeneratorPackage package, GenerationItem generationItem, bool withActivation, IMessageLogger logger)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            if (TargetFinder.FindExistingTargetItem(generationItem.SourceSymbol, generationItem.Source, generationItem.Mapping, package, logger, out var targetItem) != FindTargetStatus.Found)
+            if (TargetFinder.FindExistingTargetItem(generationItem.SourceSymbol, generationItem.Source, generationItem.Mapping, package, logger, out var targetItem, out _) != FindTargetStatus.Found)
             {
                 File.WriteAllText(generationItem.TargetFileName, generationItem.TargetContent);
                 targetItem = generationItem.TargetProjectItems.AddFromFile(generationItem.TargetFileName);

--- a/src/Unitverse/Helper/GoToTestsHelper.cs
+++ b/src/Unitverse/Helper/GoToTestsHelper.cs
@@ -10,14 +10,14 @@ namespace Unitverse.Helper
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, false);
+            var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, false, null);
 
             var status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out var targetItem);
 
             // retry the find without taking into account manually selected mappings if we didn't find it
             if (status != FindTargetStatus.Found)
             {
-                mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, true);
+                mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, true, null);
                 status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out targetItem);
             }
 

--- a/src/Unitverse/Helper/GoToTestsHelper.cs
+++ b/src/Unitverse/Helper/GoToTestsHelper.cs
@@ -12,13 +12,13 @@ namespace Unitverse.Helper
 
             var mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, false, null);
 
-            var status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out var targetItem);
+            var status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out var targetItem, out _);
 
             // retry the find without taking into account manually selected mappings if we didn't find it
             if (status != FindTargetStatus.Found)
             {
                 mapping = ProjectMappingFactory.CreateMappingFor(source.Project, package.Options, false, true, null);
-                status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out targetItem);
+                status = TargetFinder.FindExistingTargetItem(symbol, source, mapping, package, logger, out targetItem, out _);
             }
 
             switch (status)

--- a/src/Unitverse/Helper/TargetFinder.cs
+++ b/src/Unitverse/Helper/TargetFinder.cs
@@ -15,13 +15,14 @@
 
     internal static class TargetFinder
     {
-        public static FindTargetStatus FindExistingTargetItem(ISymbol symbol, ProjectItemModel source, ProjectMapping mapping, IUnitTestGeneratorPackage package, IMessageLogger messageLogger, out ProjectItem targetItem)
+        public static FindTargetStatus FindExistingTargetItem(ISymbol symbol, ProjectItemModel source, ProjectMapping mapping, IUnitTestGeneratorPackage package, IMessageLogger messageLogger, out ProjectItem targetItem, out bool wasRedirection)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
 #pragma warning disable VSTHRD010
             var nameParts = VsProjectHelper.GetNameParts(source.Item);
             targetItem = null;
+            wasRedirection = false;
 
             var targetProject = mapping.TargetProject;
             if (targetProject == null)
@@ -68,6 +69,7 @@
                     targetItem = VsProjectHelper.GetProjectItem(targetFileName);
                     if (targetItem != null)
                     {
+                        wasRedirection = true;
                         return FindTargetStatus.Found;
                     }
                 }

--- a/src/Unitverse/UnitTestGeneratorPackage.cs
+++ b/src/Unitverse/UnitTestGeneratorPackage.cs
@@ -1,6 +1,7 @@
 ﻿namespace Unitverse
 {
     using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
     using System.Threading;
     using Microsoft.VisualStudio;
@@ -40,7 +41,7 @@
             get
             {
                 var statisticsOptions = (StatisticsOptions)GetDialogPage(typeof(StatisticsOptions));
-                return new UnitTestGeneratorOptions(GenerationOptions, NamingOptions, StrategyOptions, statisticsOptions.Enabled);
+                return new UnitTestGeneratorOptions(GenerationOptions, NamingOptions, StrategyOptions, statisticsOptions.Enabled, new Dictionary<string, string>());
             }
         }
 

--- a/src/Unitverse/Views/ConfigEditorControlViewModel.cs
+++ b/src/Unitverse/Views/ConfigEditorControlViewModel.cs
@@ -29,7 +29,7 @@ namespace Unitverse.Views
             StrategyOptionsItems = EditableItemExtractor.ExtractFrom(new StrategyOptions(), strategyOptions, false).ToList();
             NamingOptionsItems = EditableItemExtractor.ExtractFrom(new NamingOptions(), namingOptions, false).ToList();
 
-            Options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false);
+            Options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false, new Dictionary<string, string>());
 
             foreach (var item in GenerationOptionsItems.Concat(StrategyOptionsItems).Concat(NamingOptionsItems))
             {

--- a/src/Unitverse/Views/GenerationDialogViewModel.cs
+++ b/src/Unitverse/Views/GenerationDialogViewModel.cs
@@ -199,7 +199,7 @@ namespace Unitverse.Views
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            IGenerationOptions resolvedOptions
+            IGenerationOptions resolvedOptions;
             if (ResultingMapping.TargetProject != null)
             {
                 resolvedOptions = OptionsResolver.DetectFrameworks(ResultingMapping.TargetProject, _originalGenerationOptions);

--- a/src/Unitverse/Views/SharedResources.xaml
+++ b/src/Unitverse/Views/SharedResources.xaml
@@ -90,7 +90,7 @@
                         Height="16"
                         Data="M17,8.5L12.25,12.32L17,16V8.5M4.7,18.4L2,16.7V7.7L5,6.7L9.3,10.03L18,2L22,4.5V20L17,22L9.34,14.66L4.7,18.4M5,14L6.86,12.28L5,10.5V14Z"
                         Fill="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}"
-                        Opacity="0.6"
+                        Opacity="0.4"
                         Stretch="Uniform" />
                 </Border>
             </Grid>

--- a/src/Unitverse/Views/SharedResources.xaml
+++ b/src/Unitverse/Views/SharedResources.xaml
@@ -12,6 +12,8 @@
         <Setter Property="Foreground" Value="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}" />
     </Style>
 
+    <BooleanToVisibilityConverter x:Key="VisibilityConverter" />
+
     <DataTemplate x:Key="TabItemTemplate" DataType="editing:TabItem">
         <Border Margin="6" BorderThickness="3,0,0,0">
             <Border.Style>
@@ -56,10 +58,65 @@
         </Border>
     </DataTemplate>
 
+    <DataTemplate x:Key="IconTemplate" DataType="editing:DisplayItem">
+        <Grid>
+            <Grid Visibility="{Binding ShowFileConfigSource, Converter={StaticResource VisibilityConverter}}">
+                <Border
+                    Margin="0,2,6,0"
+                    Background="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
+                    BorderThickness="0">
+                    <Border.ToolTip>
+                        <TextBlock>
+                            <Run Text="The configured value was set in the file '" /><Run Text="{Binding SourceFileName, Mode=OneTime}" /><Run Text="'" />
+                        </TextBlock>
+                    </Border.ToolTip>
+                    <Path
+                        Width="16"
+                        Height="16"
+                        Data="M13,9V3.5L18.5,9M6,2C4.89,2 4,2.89 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6Z"
+                        Fill="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}"
+                        Opacity="0.8"
+                        Stretch="Uniform" />
+                </Border>
+            </Grid>
+            <Grid Visibility="{Binding ShowVsConfigSource, Converter={StaticResource VisibilityConverter}}">
+                <Border
+                    Margin="0,2,6,0"
+                    Background="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
+                    BorderThickness="0"
+                    ToolTip="The configured value came from Visual Studio configuration, and was not overridden by any config files.">
+                    <Path
+                        Width="16"
+                        Height="16"
+                        Data="M17,8.5L12.25,12.32L17,16V8.5M4.7,18.4L2,16.7V7.7L5,6.7L9.3,10.03L18,2L22,4.5V20L17,22L9.34,14.66L4.7,18.4M5,14L6.86,12.28L5,10.5V14Z"
+                        Fill="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}"
+                        Opacity="0.6"
+                        Stretch="Uniform" />
+                </Border>
+            </Grid>
+            <Grid Visibility="{Binding ShowAutoDetectionSource, Converter={StaticResource VisibilityConverter}}">
+                <Border
+                    Margin="0,2,6,0"
+                    Background="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
+                    BorderThickness="0"
+                    ToolTip="The configured value was set because framework detection inspected the target project to find the right value.">
+                    <Path
+                        Width="16"
+                        Height="16"
+                        Data="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
+                        Fill="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}"
+                        Opacity="0.8"
+                        Stretch="Uniform" />
+                </Border>
+            </Grid>
+        </Grid>
+    </DataTemplate>
+
     <DataTemplate x:Key="StringItemTemplate" DataType="editing:StringEditableItem">
         <Grid Margin="6,4" HorizontalAlignment="Stretch">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="Names" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="Icons" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
@@ -74,16 +131,22 @@
                 Foreground="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}">
                 <Run Text="{Binding Text, Mode=OneTime}" /><Run Text=":" />
             </TextBlock>
-
+            <ContentControl
+                Grid.Row="0"
+                Grid.RowSpan="2"
+                Grid.Column="1"
+                VerticalAlignment="Top"
+                Content="{Binding}"
+                ContentTemplate="{StaticResource IconTemplate}" />
             <TextBox
                 Grid.Row="0"
-                Grid.Column="1"
+                Grid.Column="2"
                 Style="{DynamicResource {x:Static vsshell:VsResourceKeys.ThemedDialogTextBoxStyleKey}}"
                 Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" />
 
             <TextBlock
                 Grid.Row="1"
-                Grid.Column="1"
+                Grid.Column="2"
                 Margin="0,2"
                 FontSize="11"
                 Foreground="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}"
@@ -98,6 +161,7 @@
         <Grid Margin="6,4" HorizontalAlignment="Stretch">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="Names" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="Icons" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
@@ -109,16 +173,22 @@
                 Foreground="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}">
                 <Run Text="{Binding Text, Mode=OneTime}" /><Run Text=":" />
             </TextBlock>
-
-            <CheckBox
+            <ContentControl
+                Grid.Row="0"
+                Grid.RowSpan="2"
                 Grid.Column="1"
-                Margin="0,1"
-                IsChecked="{Binding Value}"
                 VerticalAlignment="Top"
+                Content="{Binding}"
+                ContentTemplate="{StaticResource IconTemplate}" />
+            <CheckBox
+                Grid.Column="2"
+                Margin="0,1"
+                VerticalAlignment="Top"
+                IsChecked="{Binding Value}"
                 Style="{DynamicResource {x:Static vsshell:VsResourceKeys.ThemedDialogCheckBoxStyleKey}}" />
 
             <TextBlock
-                Grid.Column="2"
+                Grid.Column="3"
                 Margin="6,2"
                 FontSize="11"
                 Foreground="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}"
@@ -133,6 +203,7 @@
         <Grid Margin="6,4" HorizontalAlignment="Stretch">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="Names" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="Icons" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
@@ -147,10 +218,16 @@
                 Foreground="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}">
                 <Run Text="{Binding Text, Mode=OneTime}" /><Run Text=":" />
             </TextBlock>
-
+            <ContentControl
+                Grid.Row="0"
+                Grid.RowSpan="2"
+                Grid.Column="1"
+                VerticalAlignment="Top"
+                Content="{Binding}"
+                ContentTemplate="{StaticResource IconTemplate}" />
             <ComboBox
                 Grid.Row="0"
-                Grid.Column="1"
+                Grid.Column="2"
                 ItemsSource="{Binding Items}"
                 SelectedItem="{Binding SelectedItem}"
                 Style="{DynamicResource {x:Static vsshell:VsResourceKeys.ThemedDialogComboBoxStyleKey}}">
@@ -163,7 +240,7 @@
 
             <TextBlock
                 Grid.Row="1"
-                Grid.Column="1"
+                Grid.Column="3"
                 Margin="0,2"
                 FontSize="11"
                 Foreground="{DynamicResource {x:Static platformUI:EnvironmentColors.ToolWindowTextBrushKey}}"
@@ -180,8 +257,6 @@
         EnumItemTemplate="{StaticResource EnumItemTemplate}"
         HeaderItemTemplate="{StaticResource HeaderItemTemplate}"
         StringItemTemplate="{StaticResource StringItemTemplate}" />
-
-    <BooleanToVisibilityConverter x:Key="VisibilityConverter" />
 
     <views:TabItemTypeVisibilityConverter x:Key="TabVisibilityConverter" />
 </ResourceDictionary>


### PR DESCRIPTION
Adding icons to the UI that show how an item was configured - showing if items have been modified by framework detection or by a config file. Adds an output message to show if options have been picked up from files.

Also contains better default value for `System.Type` variables.

Addresses #97 and #99 

Requires manual test before merge