### PR TITLE
Adding ability to emit formatted initializers and re-use fields for contructor parameter tests

### DIFF
--- a/docs/examples/AutoFixtureMockGeneration.md
+++ b/docs/examples/AutoFixtureMockGeneration.md
@@ -102,17 +102,13 @@ public class AutomaticMockGenerationExampleTests
     [Fact]
     public void CannotConstructWithNullDummyService()
     {
-        // Arrange
-        var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
-        FluentActions.Invoking(() => new AutomaticMockGenerationExample(default(IDummyService), fixture.Create<IDummyService2>())).Should().Throw<ArgumentNullException>().WithParameterName("dummyService");
+        FluentActions.Invoking(() => new AutomaticMockGenerationExample(default(IDummyService), _dummyService2)).Should().Throw<ArgumentNullException>().WithParameterName("dummyService");
     }
 
     [Fact]
     public void CannotConstructWithNullDummyService2()
     {
-        // Arrange
-        var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
-        FluentActions.Invoking(() => new AutomaticMockGenerationExample(fixture.Create<IDummyService>(), default(IDummyService2))).Should().Throw<ArgumentNullException>().WithParameterName("dummyService2");
+        FluentActions.Invoking(() => new AutomaticMockGenerationExample(_dummyService, default(IDummyService2))).Should().Throw<ArgumentNullException>().WithParameterName("dummyService2");
     }
 
     [Fact]

--- a/docs/examples/AutomaticMockGeneration.md
+++ b/docs/examples/AutomaticMockGeneration.md
@@ -159,13 +159,13 @@ public class AutomaticMockGenerationExampleTests
     [Fact]
     public void CannotConstructWithNullDummyService()
     {
-        FluentActions.Invoking(() => new AutomaticMockGenerationExample(default(IDummyService), Substitute.For<IDummyService2>())).Should().Throw<ArgumentNullException>().WithParameterName("dummyService");
+        FluentActions.Invoking(() => new AutomaticMockGenerationExample(default(IDummyService), _dummyService2)).Should().Throw<ArgumentNullException>().WithParameterName("dummyService");
     }
 
     [Fact]
     public void CannotConstructWithNullDummyService2()
     {
-        FluentActions.Invoking(() => new AutomaticMockGenerationExample(Substitute.For<IDummyService>(), default(IDummyService2))).Should().Throw<ArgumentNullException>().WithParameterName("dummyService2");
+        FluentActions.Invoking(() => new AutomaticMockGenerationExample(_dummyService, default(IDummyService2))).Should().Throw<ArgumentNullException>().WithParameterName("dummyService2");
     }
 
     [Fact]

--- a/docs/examples/ConstrainedGenericType.md
+++ b/docs/examples/ConstrainedGenericType.md
@@ -52,7 +52,11 @@ public class TestClass_2Tests
     public TestClass_2Tests()
     {
         _insta = new Test { ThisIsAProperty = 534011718 };
-        _insta2 = new TestBoth { ThisIsAProperty = 237820880, ThisIsAnotherProperty = 1002897798 };
+        _insta2 = new TestBoth
+        {
+            ThisIsAProperty = 237820880,
+            ThisIsAnotherProperty = 1002897798
+        };
         _testClass = new TestClass<T, R>(_insta, _insta2);
     }
 
@@ -69,13 +73,13 @@ public class TestClass_2Tests
     [Fact]
     public void CannotConstructWithNullInsta()
     {
-        FluentActions.Invoking(() => new TestClass<T, R>(default(T), new TestBoth { ThisIsAProperty = 1657007234, ThisIsAnotherProperty = 1412011072 })).Should().Throw<ArgumentNullException>().WithParameterName("insta");
+        FluentActions.Invoking(() => new TestClass<T, R>(default(T), _insta2)).Should().Throw<ArgumentNullException>().WithParameterName("insta");
     }
 
     [Fact]
     public void CannotConstructWithNullInsta2()
     {
-        FluentActions.Invoking(() => new TestClass<T, R>(new Test { ThisIsAProperty = 929393559 }, default(R))).Should().Throw<ArgumentNullException>().WithParameterName("insta2");
+        FluentActions.Invoking(() => new TestClass<T, R>(_insta, default(R))).Should().Throw<ArgumentNullException>().WithParameterName("insta2");
     }
 
     [Fact]

--- a/docs/examples/MappingMethod.md
+++ b/docs/examples/MappingMethod.md
@@ -42,7 +42,11 @@ public class MappingClassTests
     public void CanCallMap()
     {
         // Arrange
-        var inputClass = new InputClass { SomeOtherProperty = "TestValue534011718", InputOnlyProperty = "TestValue237820880" };
+        var inputClass = new InputClass
+        {
+            SomeOtherProperty = "TestValue534011718",
+            InputOnlyProperty = "TestValue237820880"
+        };
 
         // Act
         var result = _testClass.Map(inputClass);
@@ -61,7 +65,11 @@ public class MappingClassTests
     public void MapPerformsMapping()
     {
         // Arrange
-        var inputClass = new InputClass { SomeOtherProperty = "TestValue1002897798", InputOnlyProperty = "TestValue1657007234" };
+        var inputClass = new InputClass
+        {
+            SomeOtherProperty = "TestValue1002897798",
+            InputOnlyProperty = "TestValue1657007234"
+        };
 
         // Act
         var result = _testClass.Map(inputClass);

--- a/docs/examples/NullableReferenceTypes.md
+++ b/docs/examples/NullableReferenceTypes.md
@@ -74,7 +74,7 @@ public class TestClassTests
     [Fact]
     public void CannotConstructWithNullTest()
     {
-        FluentActions.Invoking(() => new TestClass(default(ITest), "TestValue1657007234")).Should().Throw<ArgumentNullException>().WithParameterName("test");
+        FluentActions.Invoking(() => new TestClass(default(ITest), _someOtherThing)).Should().Throw<ArgumentNullException>().WithParameterName("test");
     }
 
     [Theory]
@@ -83,7 +83,7 @@ public class TestClassTests
     [InlineData("   ")]
     public void CannotConstructWithInvalidNotNullable(string value)
     {
-        FluentActions.Invoking(() => new TestClass(value, "TestValue1412011072")).Should().Throw<ArgumentNullException>().WithParameterName("notNullable");
+        FluentActions.Invoking(() => new TestClass(value, _nullable)).Should().Throw<ArgumentNullException>().WithParameterName("notNullable");
     }
 
     [Theory]
@@ -91,7 +91,7 @@ public class TestClassTests
     [InlineData("   ")]
     public void CannotConstructWithInvalidNullable(string value)
     {
-        FluentActions.Invoking(() => new TestClass("TestValue929393559", value)).Should().Throw<ArgumentNullException>().WithParameterName("nullable");
+        FluentActions.Invoking(() => new TestClass(_notNullable, value)).Should().Throw<ArgumentNullException>().WithParameterName("nullable");
     }
 
     [Theory]
@@ -100,16 +100,16 @@ public class TestClassTests
     [InlineData("   ")]
     public void CannotConstructWithInvalidSomeOtherThing(string value)
     {
-        FluentActions.Invoking(() => new TestClass(Substitute.For<ITest>(), value)).Should().Throw<ArgumentNullException>().WithParameterName("someOtherThing");
+        FluentActions.Invoking(() => new TestClass(_testITest, value)).Should().Throw<ArgumentNullException>().WithParameterName("someOtherThing");
     }
 
     [Fact]
     public void CanCallGetFullName()
     {
         // Arrange
-        var first = "TestValue760389092";
-        var middle = "TestValue2026928803";
-        var last = "TestValue217468053";
+        var first = "TestValue1657007234";
+        var middle = "TestValue1412011072";
+        var last = "TestValue929393559";
 
         // Act
         var result = _testClass.GetFullName(first, middle, last);
@@ -124,7 +124,7 @@ public class TestClassTests
     [InlineData("   ")]
     public void CannotCallGetFullNameWithInvalidFirst(string value)
     {
-        FluentActions.Invoking(() => _testClass.GetFullName(value, "TestValue1379662799", "TestValue61497087")).Should().Throw<ArgumentNullException>().WithParameterName("first");
+        FluentActions.Invoking(() => _testClass.GetFullName(value, "TestValue760389092", "TestValue2026928803")).Should().Throw<ArgumentNullException>().WithParameterName("first");
     }
 
     [Theory]
@@ -132,7 +132,7 @@ public class TestClassTests
     [InlineData("   ")]
     public void CannotCallGetFullNameWithInvalidMiddle(string value)
     {
-        FluentActions.Invoking(() => _testClass.GetFullName("TestValue532638534", value, "TestValue687431273")).Should().Throw<ArgumentNullException>().WithParameterName("middle");
+        FluentActions.Invoking(() => _testClass.GetFullName("TestValue217468053", value, "TestValue1379662799")).Should().Throw<ArgumentNullException>().WithParameterName("middle");
     }
 
     [Theory]
@@ -141,7 +141,7 @@ public class TestClassTests
     [InlineData("   ")]
     public void CannotCallGetFullNameWithInvalidLast(string value)
     {
-        FluentActions.Invoking(() => _testClass.GetFullName("TestValue2125508764", "TestValue1464848243", value)).Should().Throw<ArgumentNullException>().WithParameterName("last");
+        FluentActions.Invoking(() => _testClass.GetFullName("TestValue61497087", "TestValue532638534", value)).Should().Throw<ArgumentNullException>().WithParameterName("last");
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class TestClassTests
     {
         // Arrange
         var test = Substitute.For<ITest>();
-        var someOtherThing = "TestValue1406361028";
+        var someOtherThing = "TestValue687431273";
 
         // Act
         _testClass.SomeMethod(test, someOtherThing);
@@ -161,7 +161,7 @@ public class TestClassTests
     [Fact]
     public void CannotCallSomeMethodWithNullTest()
     {
-        FluentActions.Invoking(() => _testClass.SomeMethod(default(ITest), "TestValue607156385")).Should().Throw<ArgumentNullException>().WithParameterName("test");
+        FluentActions.Invoking(() => _testClass.SomeMethod(default(ITest), "TestValue2125508764")).Should().Throw<ArgumentNullException>().WithParameterName("test");
     }
 
     [Theory]

--- a/docs/examples/PocoInitialization.md
+++ b/docs/examples/PocoInitialization.md
@@ -33,7 +33,12 @@ public class ConsumingClassTests
 
     public ConsumingClassTests()
     {
-        _poco = new SomePoco { Identity = 534011718, Description = "TestValue237820880", UniqueCode = new Guid("97408286-a3e4-cf95-ff46-699c73c4a1cd") };
+        _poco = new SomePoco
+        {
+            Identity = 534011718,
+            Description = "TestValue237820880",
+            UniqueCode = new Guid("97408286-a3e4-cf95-ff46-699c73c4a1cd")
+        };
         _testClass = new ConsumingClass(_poco);
     }
 

--- a/docs/examples/PropertyInitializationChecks.md
+++ b/docs/examples/PropertyInitializationChecks.md
@@ -52,7 +52,7 @@ public class ExampleClassTests
     [InlineData("   ")]
     public void CannotConstructWithInvalidDescription(string value)
     {
-        FluentActions.Invoking(() => new ExampleClass(1512368656, value, new Guid("4e5b1334-6fa3-a584-4adf-7a0ea09ce3c1"))).Should().Throw<ArgumentNullException>().WithParameterName("description");
+        FluentActions.Invoking(() => new ExampleClass(_identity, value, _uniqueCode)).Should().Throw<ArgumentNullException>().WithParameterName("description");
     }
 
     [Fact]

--- a/docs/examples/RecordTypeInitProperties.md
+++ b/docs/examples/RecordTypeInitProperties.md
@@ -47,14 +47,28 @@ public class PersonTests
         _middleName = "TestValue1321446349";
         _lastName = "TestValue1512368656";
         _iceCreamFlavours = new[] { "TestValue1507096884", "TestValue2039633683", "TestValue200550235" };
-        _testClass = new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours };
+        _testClass = new Person
+        {
+            Id = _id,
+            FirstName = _firstName,
+            MiddleName = _middleName,
+            LastName = _lastName,
+            IceCreamFlavours = _iceCreamFlavours
+        };
     }
 
     [Fact]
     public void CanInitialize()
     {
         // Act
-        var instance = new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours };
+        var instance = new Person
+        {
+            Id = _id,
+            FirstName = _firstName,
+            MiddleName = _middleName,
+            LastName = _lastName,
+            IceCreamFlavours = _iceCreamFlavours
+        };
 
         // Assert
         instance.Should().NotBeNull();
@@ -63,7 +77,14 @@ public class PersonTests
     [Fact]
     public void CannotInitializeWithNullIceCreamFlavours()
     {
-        FluentActions.Invoking(() => new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = default(IList<string>) }).Should().Throw<ArgumentNullException>().WithParameterName("IceCreamFlavours");
+        FluentActions.Invoking(() => new Person
+        {
+            Id = _id,
+            FirstName = _firstName,
+            MiddleName = _middleName,
+            LastName = _lastName,
+            IceCreamFlavours = default(IList<string>)
+        }).Should().Throw<ArgumentNullException>().WithParameterName("IceCreamFlavours");
     }
 
     [Theory]
@@ -72,7 +93,14 @@ public class PersonTests
     [InlineData("   ")]
     public void CannotInitializeWithInvalidFirstName(string value)
     {
-        FluentActions.Invoking(() => new Person { Id = _id, FirstName = value, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours }).Should().Throw<ArgumentNullException>().WithParameterName("FirstName");
+        FluentActions.Invoking(() => new Person
+        {
+            Id = _id,
+            FirstName = value,
+            MiddleName = _middleName,
+            LastName = _lastName,
+            IceCreamFlavours = _iceCreamFlavours
+        }).Should().Throw<ArgumentNullException>().WithParameterName("FirstName");
     }
 
     [Theory]
@@ -80,7 +108,14 @@ public class PersonTests
     [InlineData("   ")]
     public void CannotInitializeWithInvalidMiddleName(string value)
     {
-        FluentActions.Invoking(() => new Person { Id = _id, FirstName = _firstName, MiddleName = value, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours }).Should().Throw<ArgumentNullException>().WithParameterName("MiddleName");
+        FluentActions.Invoking(() => new Person
+        {
+            Id = _id,
+            FirstName = _firstName,
+            MiddleName = value,
+            LastName = _lastName,
+            IceCreamFlavours = _iceCreamFlavours
+        }).Should().Throw<ArgumentNullException>().WithParameterName("MiddleName");
     }
 
     [Theory]
@@ -89,14 +124,28 @@ public class PersonTests
     [InlineData("   ")]
     public void CannotInitializeWithInvalidLastName(string value)
     {
-        FluentActions.Invoking(() => new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = value, IceCreamFlavours = _iceCreamFlavours }).Should().Throw<ArgumentNullException>().WithParameterName("LastName");
+        FluentActions.Invoking(() => new Person
+        {
+            Id = _id,
+            FirstName = _firstName,
+            MiddleName = _middleName,
+            LastName = value,
+            IceCreamFlavours = _iceCreamFlavours
+        }).Should().Throw<ArgumentNullException>().WithParameterName("LastName");
     }
 
     [Fact]
     public void ImplementsIEquatable_Person()
     {
         // Arrange
-        var same = new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours };
+        var same = new Person
+        {
+            Id = _id,
+            FirstName = _firstName,
+            MiddleName = _middleName,
+            LastName = _lastName,
+            IceCreamFlavours = _iceCreamFlavours
+        };
         var different = new Person();
 
         // Assert

--- a/src/Unitverse.Core.Tests/Resources/NestedPocoFormatting.txt
+++ b/src/Unitverse.Core.Tests/Resources/NestedPocoFormatting.txt
@@ -1,0 +1,57 @@
+// # EmitMultilinePocoInitializers=true
+namespace TestNamespace.SubNameSpace
+{
+	using System;
+
+    public class SomePocoNested
+    {
+        public int ThisIsAProperty {get;set;}
+        public string ThisIsAProperty2 {get;set;}
+        public Guid ThisIsAProperty3 {get;set;}
+        public Guid? ThisIsAProperty4 {get;set;}
+        public int ThisIsAProperty5 {get;private set;}
+		private int ThisIsAProperty6 {get;set;}
+        public Guid ThisIsAProperty7 {get;set;}
+        public Guid ThisIsAProperty8 {get;set;}
+        public Guid ThisIsAProperty9 {get;set;}
+    }
+
+    public class SomePocoNested2
+    {
+        public int ThisIsAProperty {get;set;}
+        public string ThisIsAProperty2 {get;set;}
+        public Guid ThisIsAProperty3 {get;set;}
+        public Guid? ThisIsAProperty4 {get;set;}
+        public int ThisIsAProperty5 {get;private set;}
+		private int ThisIsAProperty6 {get;set;}
+        public Guid ThisIsAProperty7 {get;set;}
+        public Guid ThisIsAProperty8 {get;set;}
+        public Guid ThisIsAProperty9 {get;set;}
+    }
+
+
+    public class SomePoco
+    {
+        public SomePocoNested[] ThisIsAProperty {get;set;}
+        public SomePocoNested2 ThisIsAProperty2 {get;set;}
+        public Guid ThisIsAProperty3 {get;set;}
+        public Guid? ThisIsAProperty4 {get;set;}
+        public int ThisIsAProperty5 {get;private set;}
+		private int ThisIsAProperty6 {get;set;}
+        public Guid ThisIsAProperty7 {get;set;}
+        public Guid ThisIsAProperty8 {get;set;}
+        public Guid ThisIsAProperty9 {get;set;}
+    }
+
+    public class TestClass
+    {
+		SomePoco _poco;
+
+        public TestClass(SomePoco poco, string someOtherProp)
+        {
+			_poco = poco;
+        }
+ 
+        public SomePoco Poco => _poco;
+    }
+}

--- a/src/Unitverse.Core.Tests/Resources/OldStyleConstructorFieldTesting.txt
+++ b/src/Unitverse.Core.Tests/Resources/OldStyleConstructorFieldTesting.txt
@@ -1,0 +1,22 @@
+// # UseFieldsForConstructorParameterTests=false
+namespace TestNamespace.SubNameSpace
+{
+	using System;
+
+    public class SomePoco
+    {
+        public int ThisIsAProperty {get;set;}
+    }
+
+    public class TestClass
+    {
+		SomePoco _poco;
+
+        public TestClass(SomePoco poco, string s, SomePoco poco2)
+        {
+			_poco = poco;
+        }
+ 
+        public SomePoco Poco => _poco;
+    }
+}

--- a/src/Unitverse.Core.Tests/TestClasses.Designer.cs
+++ b/src/Unitverse.Core.Tests/TestClasses.Designer.cs
@@ -287,7 +287,9 @@ namespace Unitverse.Core.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to namespace TestNamespace.SubNameSpace
+        ///   Looks up a localized string similar to // # ForceAsyncSuffix=true
+        ///
+        ///namespace TestNamespace.SubNameSpace
         ///{
         ///    public class TestClass
         ///    {
@@ -300,7 +302,7 @@ namespace Unitverse.Core.Tests {
         ///	    public System.Threading.Tasks.Task&lt;int&gt; ThisIsAnAsyncMethodWithReturnType(string methodName, int methodValue)
         ///	    {
         ///		    System.Console.WriteLine(&quot;Testing this&quot;);
-        ///			return System.Threading.Tasks.Task.FromRes [rest of string was truncated]&quot;;.
+        ///			return Syste [rest of string was truncated]&quot;;.
         /// </summary>
         public static string AsyncMethod {
             get {
@@ -1455,6 +1457,29 @@ namespace Unitverse.Core.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // # EmitMultilinePocoInitializers=true
+        ///namespace TestNamespace.SubNameSpace
+        ///{
+        ///	using System;
+        ///
+        ///    public class SomePocoNested
+        ///    {
+        ///        public int ThisIsAProperty {get;set;}
+        ///        public string ThisIsAProperty2 {get;set;}
+        ///        public Guid ThisIsAProperty3 {get;set;}
+        ///        public Guid? ThisIsAProperty4 {get;set;}
+        ///        public int ThisIsAProperty5 {get;private set;}
+        ///		private int ThisIsAProperty6 {get;set;}
+        ///        public Guid ThisIsAProperty7 {get;set;}
+        ///        public Guid ThisIsA [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string NestedPocoFormatting {
+            get {
+                return ResourceManager.GetString("NestedPocoFormatting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to namespace Unitverse.Web.Services.Flow
         ///{
         ///    public interface P
@@ -1505,6 +1530,35 @@ namespace Unitverse.Core.Tests {
         public static string NullableReferenceTypes {
             get {
                 return ResourceManager.GetString("NullableReferenceTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to namespace TestNamespace.SubNameSpace
+        ///{
+        ///	using System;
+        ///
+        ///    public class SomePoco
+        ///    {
+        ///        public int ThisIsAProperty {get;set;}
+        ///    }
+        ///
+        ///    public class TestClass
+        ///    {
+        ///		SomePoco _poco;
+        ///
+        ///        public TestClass(SomePoco poco, string s, SomePoco poco2)
+        ///        {
+        ///			_poco = poco;
+        ///        }
+        /// 
+        ///        public SomePoco Poco =&gt; _poco;
+        ///    }
+        ///}.
+        /// </summary>
+        public static string OldStyleConstructorFieldTesting {
+            get {
+                return ResourceManager.GetString("OldStyleConstructorFieldTesting", resourceCulture);
             }
         }
         

--- a/src/Unitverse.Core.Tests/TestClasses.resx
+++ b/src/Unitverse.Core.Tests/TestClasses.resx
@@ -262,11 +262,17 @@
   <data name="NestedClassTestFile" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\NestedClassTestFile.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="NestedPocoFormatting" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\NestedPocoFormatting.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="NotNullConstraint" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\NotNullConstraint.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="NullableReferenceTypes" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\NullableReferenceTypes.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="OldStyleConstructorFieldTesting" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\OldStyleConstructorFieldTesting.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="OperatorOverloading" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\OperatorOverloading.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>

--- a/src/Unitverse.Core/Helpers/AssignmentValueHelper.cs
+++ b/src/Unitverse.Core/Helpers/AssignmentValueHelper.cs
@@ -364,7 +364,7 @@
                 if (initializableProperties.Any() && !methods.Any())
                 {
                     {
-                        expressionSyntax = Generate.ObjectCreation(namedType.ToTypeSyntax(frameworkSet.Context), initializableProperties.Select(x =>
+                        expressionSyntax = Generate.ObjectCreation(frameworkSet.Options.GenerationOptions, namedType.ToTypeSyntax(frameworkSet.Context), initializableProperties.Select(x =>
                         {
                             var visitedTypesThisMember = new HashSet<string>(visitedTypes, StringComparer.OrdinalIgnoreCase);
                             return Generate.Assignment(x.Name, GetDefaultAssignmentValue(x.Type, semanticModel, visitedTypesThisMember, frameworkSet));

--- a/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
+++ b/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
@@ -88,5 +88,9 @@
         public bool SkipInternalTypesOnMultipleGeneration => _baseOptions.SkipInternalTypesOnMultipleGeneration;
 
         public string DefaultFailureMessage => _baseOptions.DefaultFailureMessage;
+
+        public bool EmitMultilinePocoInitializers => _baseOptions.EmitMultilinePocoInitializers;
+
+        public bool UseFieldsForConstructorParameterTests => _baseOptions.UseFieldsForConstructorParameterTests;
     }
 }

--- a/src/Unitverse.Core/Helpers/Generate.cs
+++ b/src/Unitverse.Core/Helpers/Generate.cs
@@ -365,7 +365,7 @@
             return SyntaxFactory.ObjectCreationExpression(type).WithArgumentList(Arguments(arguments));
         }
 
-        public static ObjectCreationExpressionSyntax ObjectCreation(TypeSyntax type, IEnumerable<AssignmentExpressionSyntax> initializers)
+        public static ObjectCreationExpressionSyntax ObjectCreation(IGenerationOptions generationOptions, TypeSyntax type, IEnumerable<AssignmentExpressionSyntax> initializers)
         {
             if (initializers == null)
             {
@@ -377,7 +377,13 @@
             {
                 if (nodes.Count > 0)
                 {
-                    nodes.Add(SyntaxFactory.Token(SyntaxKind.CommaToken));
+                    var commaToken = SyntaxFactory.Token(SyntaxKind.CommaToken);
+                    if (generationOptions.EmitMultilinePocoInitializers)
+                    {
+                        commaToken = commaToken.WithTrailingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.EndOfLineTrivia, "\n"));
+                    }
+
+                    nodes.Add(commaToken);
                 }
 
                 nodes.Add(initializer);

--- a/src/Unitverse.Core/Models/ClassModel.cs
+++ b/src/Unitverse.Core/Models/ClassModel.cs
@@ -283,7 +283,7 @@
                 var initializableProperties = Properties.Where(x => x.HasInit).ToList();
                 if (initializableProperties.Any())
                 {
-                    return Generate.ObjectCreation(TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetConstructorFieldReference(x, frameworkSet))));
+                    return Generate.ObjectCreation(frameworkSet.Options.GenerationOptions, TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetConstructorFieldReference(x, frameworkSet))));
                 }
             }
 

--- a/src/Unitverse.Core/Options/IGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/IGenerationOptions.cs
@@ -67,5 +67,9 @@
         bool SkipInternalTypesOnMultipleGeneration { get; }
 
         string DefaultFailureMessage { get; }
+
+        bool EmitMultilinePocoInitializers { get; }
+
+        bool UseFieldsForConstructorParameterTests { get; }
     }
 }

--- a/src/Unitverse.Core/Options/MutableGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/MutableGenerationOptions.cs
@@ -45,6 +45,8 @@
             UseFieldForAutoFixture = options.UseFieldForAutoFixture;
             DefaultFailureMessage = options.DefaultFailureMessage;
             SkipInternalTypesOnMultipleGeneration = options.SkipInternalTypesOnMultipleGeneration;
+            EmitMultilinePocoInitializers = options.EmitMultilinePocoInitializers;
+            UseFieldsForConstructorParameterTests = options.UseFieldsForConstructorParameterTests;
         }
 
         public TestFrameworkTypes FrameworkType { get; set; }
@@ -112,5 +114,9 @@
         public bool SkipInternalTypesOnMultipleGeneration { get; set; }
 
         public string DefaultFailureMessage { get; set; }
+
+        public bool EmitMultilinePocoInitializers { get; set; }
+
+        public bool UseFieldsForConstructorParameterTests { get; set; }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
@@ -81,7 +81,7 @@
                     return model.GetConstructorFieldReference(propertyModel, _frameworkSet);
                 }
 
-                var methodCall = Generate.ObjectCreation(model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
+                var methodCall = Generate.ObjectCreation(_frameworkSet.Options.GenerationOptions, model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
                 generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall, property.Name));
 
                 yield return generatedMethod;

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/ParameterCheckConstructorGenerationStrategyBase.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/ParameterCheckConstructorGenerationStrategyBase.cs
@@ -1,0 +1,63 @@
+﻿namespace Unitverse.Core.Strategies.ClassLevelGeneration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Unitverse.Core.Frameworks;
+    using Unitverse.Core.Helpers;
+    using Unitverse.Core.Models;
+    using Unitverse.Core.Options;
+
+    public abstract class ParameterCheckConstructorGenerationStrategyBase : IGenerationStrategy<ClassModel>
+    {
+        protected IFrameworkSet FrameworkSet { get; }
+
+        public bool IsExclusive => false;
+
+        public int Priority => 1;
+
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.ConstructorParameterChecksAreEnabled;
+
+        public ParameterCheckConstructorGenerationStrategyBase(IFrameworkSet frameworkSet)
+        {
+            FrameworkSet = frameworkSet ?? throw new ArgumentNullException(nameof(frameworkSet));
+        }
+
+        public bool CanHandle(ClassModel method, ClassModel model)
+        {
+            if (method is null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            if (model.Declaration is RecordDeclarationSyntax)
+            {
+                return false;
+            }
+
+            return model.Constructors.SelectMany(x => x.Parameters).Any(CanHandleParameter) && !model.IsStatic;
+        }
+
+        protected abstract bool CanHandleParameter(ParameterModel parameter);
+
+        public abstract IEnumerable<SectionedMethodHandler> Create(ClassModel member, ClassModel model, NamingContext namingContext);
+
+        protected ExpressionSyntax GetFieldReferenceOrNewObjectFor(ClassModel model, ParameterModel parameter)
+        {
+            if (FrameworkSet.Options.GenerationOptions.UseFieldsForConstructorParameterTests)
+            {
+                return model.GetConstructorFieldReference(parameter, FrameworkSet);
+            }
+
+            return AssignmentValueHelper.GetDefaultAssignmentValue(parameter.TypeInfo, model.SemanticModel, FrameworkSet);
+        }
+    }
+}

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
@@ -11,42 +11,19 @@
     using Unitverse.Core.Models;
     using Unitverse.Core.Options;
 
-    public class StringParameterCheckConstructorGenerationStrategy : IGenerationStrategy<ClassModel>
+    public class StringParameterCheckConstructorGenerationStrategy : ParameterCheckConstructorGenerationStrategyBase
     {
-        private readonly IFrameworkSet _frameworkSet;
-
         public StringParameterCheckConstructorGenerationStrategy(IFrameworkSet frameworkSet)
+            : base(frameworkSet)
         {
-            _frameworkSet = frameworkSet ?? throw new ArgumentNullException(nameof(frameworkSet));
         }
 
-        public bool IsExclusive => false;
-
-        public int Priority => 1;
-
-        public Func<IStrategyOptions, bool> IsEnabled => x => x.ConstructorParameterChecksAreEnabled;
-
-        public bool CanHandle(ClassModel method, ClassModel model)
+        protected override bool CanHandleParameter(ParameterModel parameter)
         {
-            if (method is null)
-            {
-                throw new ArgumentNullException(nameof(method));
-            }
-
-            if (model is null)
-            {
-                throw new ArgumentNullException(nameof(model));
-            }
-
-            if (model.Declaration is RecordDeclarationSyntax)
-            {
-                return false;
-            }
-
-            return model.Constructors.SelectMany(x => x.Parameters).Any(x => x.TypeInfo.Type != null && x.TypeInfo.Type.IsReferenceType && x.TypeInfo.Type.SpecialType == SpecialType.System_String) && !model.IsStatic;
+            return parameter.TypeInfo.Type != null && parameter.TypeInfo.Type.IsReferenceType && parameter.TypeInfo.Type.SpecialType == SpecialType.System_String;
         }
 
-        public IEnumerable<SectionedMethodHandler> Create(ClassModel method, ClassModel model, NamingContext namingContext)
+        public override IEnumerable<SectionedMethodHandler> Create(ClassModel method, ClassModel model, NamingContext namingContext)
         {
             if (method is null)
             {
@@ -65,13 +42,13 @@
                 namingContext = namingContext.WithParameterName(nullableParameter.ToPascalCase());
                 var isNonNullable = model.Constructors.SelectMany(x => x.Parameters.Where(p => string.Equals(p.Name, nullableParameter, StringComparison.OrdinalIgnoreCase))).All(x => x.IsNullableTypeSyntax || x.HasNullDefaultValue);
                 object?[] testValues = isNonNullable ? new object?[] { string.Empty, "   " } : new object?[] { null, string.Empty, "   " };
-                var generatedMethod = _frameworkSet.CreateTestCaseMethod(_frameworkSet.NamingProvider.CannotConstructWithInvalid, namingContext, false, false, SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)), testValues, "Checks that the constructor throws when the " + nullableParameter + " parameter is null, empty or white space.");
+                var generatedMethod = FrameworkSet.CreateTestCaseMethod(FrameworkSet.NamingProvider.CannotConstructWithInvalid, namingContext, false, false, SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)), testValues, "Checks that the constructor throws when the " + nullableParameter + " parameter is null, empty or white space.");
 
                 foreach (var constructorModel in model.Constructors.Where(x => x.Parameters.Any(p => string.Equals(p.Name, nullableParameter, StringComparison.OrdinalIgnoreCase))))
                 {
-                    var paramExpressions = constructorModel.Parameters.Select(param => string.Equals(param.Name, nullableParameter, StringComparison.OrdinalIgnoreCase) ? SyntaxFactory.IdentifierName("value") : AssignmentValueHelper.GetDefaultAssignmentValue(param.TypeInfo, model.SemanticModel, _frameworkSet)).ToList();
+                    var paramExpressions = constructorModel.Parameters.Select(param => string.Equals(param.Name, nullableParameter, StringComparison.OrdinalIgnoreCase) ? SyntaxFactory.IdentifierName("value") : GetFieldReferenceOrNewObjectFor(model, param)).ToList();
                     var methodCall = Generate.ObjectCreation(model.TypeSyntax, paramExpressions.ToArray());
-                    generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall, nullableParameter));
+                    generatedMethod.Emit(FrameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall, nullableParameter));
                 }
 
                 yield return generatedMethod;

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
@@ -78,7 +78,7 @@
                     return model.GetConstructorFieldReference(propertyModel, _frameworkSet);
                 }
 
-                var methodCall = Generate.ObjectCreation(model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
+                var methodCall = Generate.ObjectCreation(_frameworkSet.Options.GenerationOptions, model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
                 generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall, property.Name));
 
                 yield return generatedMethod;

--- a/src/Unitverse.Specs/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGeneration.feature
+++ b/src/Unitverse.Specs/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGeneration.feature
@@ -50,4 +50,4 @@ public class TestClass
 		And I expect it to have the attribute 'DataRow(null)'
 		And I expect it to have the attribute 'DataRow("")'
 		And I expect it to have the attribute 'DataRow("   ")'
-		And I expect it to contain the statement 'Assert.ThrowsException<ArgumentNullException>(() => newTestClass(value, default(ITest)));'
+		And I expect it to contain the statement 'Assert.ThrowsException<ArgumentNullException>(() => newTestClass(value, _iTest));'

--- a/src/Unitverse.Specs/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGeneration.feature.cs
+++ b/src/Unitverse.Specs/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGeneration.feature.cs
@@ -165,7 +165,7 @@ this.ScenarioInitialize(scenarioInfo);
 #line hidden
 #line 53
   testRunner.And("I expect it to contain the statement \'Assert.ThrowsException<ArgumentNullExceptio" +
-                        "n>(() => newTestClass(value, default(ITest)));\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+                        "n>(() => newTestClass(value, _iTest));\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
             this.ScenarioCleanup();

--- a/src/Unitverse.Tests.Common/DefaultGenerationOptions.cs
+++ b/src/Unitverse.Tests.Common/DefaultGenerationOptions.cs
@@ -70,5 +70,9 @@
         public bool SkipInternalTypesOnMultipleGeneration { get; set; } = false;
 
         public string DefaultFailureMessage { get; set; } = "Create or modify test";
+
+        public bool EmitMultilinePocoInitializers { get; set; } = true;
+
+        public bool UseFieldsForConstructorParameterTests { get; set; } = true;
     }
 }

--- a/src/Unitverse/Options/GenerationOptions.cs
+++ b/src/Unitverse/Options/GenerationOptions.cs
@@ -173,5 +173,15 @@
         [DisplayName("Default failure message")]
         [Description("The message to use in failure asserts for skeleton tests")]
         public string DefaultFailureMessage { get; set; } = "Create or modify test";
+
+        [Category("Generation")]
+        [DisplayName("Emit multi-line initializers")]
+        [Description("Whether to format type initializers over multiple lines for readability")] 
+        public bool EmitMultilinePocoInitializers { get; set; } = true;
+
+        [Category("Generation")]
+        [DisplayName("Use fields for constructor parameter tests")]
+        [Description("Whether to use fields for constructor parameter tests, or to create a new value for every test")]
+        public bool UseFieldsForConstructorParameterTests { get; set; } = true;
     }
 }


### PR DESCRIPTION
Note that this PR does introduce a behaviour change. Anyone who wants to revert to the old behaviour can set the relevant options.

Resolves #230 